### PR TITLE
fix: address review comments from PR #3

### DIFF
--- a/backend/src/zondarr/config.py
+++ b/backend/src/zondarr/config.py
@@ -41,6 +41,12 @@ class Settings(msgspec.Struct, kw_only=True, forbid_unknown_fields=True):
 
     # Security
     secret_key: Annotated[str, msgspec.Meta(min_length=32)]
+    secure_cookies: Annotated[
+        bool,
+        msgspec.Meta(
+            description="Set True when serving over HTTPS to enforce Secure flag on cookies"
+        ),
+    ] = False
 
     # Media server credentials (optional, override database values)
     plex_url: str | None = None
@@ -95,6 +101,8 @@ def load_settings() -> Settings:
             if origin.strip()
         ],
         "secret_key": secret_key,
+        "secure_cookies": os.environ.get("SECURE_COOKIES", "").lower()
+        in ("true", "1", "yes"),
         "expiration_check_interval_seconds": int(
             os.environ.get("EXPIRATION_CHECK_INTERVAL_SECONDS", "3600")
         ),


### PR DESCRIPTION
## Summary

- Make the cookie `secure` flag settings-driven via a `SECURE_COOKIES` env var instead of hardcoding `secure=False`, allowing proper configuration per environment.
- Add Plex server owner verification to the auth flow to prevent any Plex user from auto-provisioning as admin. The authenticating user's email is now validated against the server owner's email using the configured `PLEX_TOKEN`.

## Test plan

- [ ] Verify login with Plex server owner credentials succeeds and provisions admin
- [ ] Verify login with a non-owner Plex account is rejected
- [ ] Verify `SECURE_COOKIES=true` sets the secure flag on auth cookies
- [ ] Verify `SECURE_COOKIES=false` (default) leaves cookies without the secure flag