### PR TITLE
fix: remove duplicate CSS reset that broke button styling

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,5 +1,5 @@
 /* UnoCSS is imported via +layout.svelte */
-@import "@unocss/reset/tailwind.css";
+/* Reset is handled by presetWind4({ preflights: { reset: true } }) in uno.config.ts */
 
 /* Control Room Design Tokens */
 :root {


### PR DESCRIPTION
## Summary

- Removed the redundant `@import "@unocss/reset/tailwind.css"` from `app.css`
- `presetWind4({ preflights: { reset: true } })` in `uno.config.ts` already provides a complete CSS reset inside the UnoCSS virtual stylesheet, making the separate import unnecessary

## Problem

The duplicate reset loaded as a separate stylesheet **after** the UnoCSS utility stylesheet. Its `[type="submit"]` and `[type="button"]` attribute selectors have specificity `(0,1,0)`, which ties with utility classes like `.bg-cr-accent`. Because the reset appeared later in source order, it won the cascade and forced `background-color: transparent` on all typed buttons.

This caused the "Sign in" and "Create admin account" buttons on the login and setup pages to render with no visible background in their default state. Hover states were unaffected because the `:hover` pseudo-class raises specificity to `(0,2,0)`, which beats the reset.

## Test plan

- [ ] Verify the "Sign in" button on `/login` has the accent background color in both light and dark mode
- [ ] Verify hover darkens the button as expected
- [ ] Verify the "Create admin account" button on `/setup` renders correctly
- [ ] Verify the "Sign in with Plex" outline button is unaffected
- [ ] Confirm `bun run build` succeeds without errors