### PR TITLE
fix: handle wizard step enum serialization and invitation lazy-load errors

### DIFF
--- a/backend/src/zondarr/api/invitations.py
+++ b/backend/src/zondarr/api/invitations.py
@@ -571,11 +571,14 @@ class InvitationController(Controller):
         Returns:
             WizardStepResponse.
         """
+        interaction_type = step.interaction_type
+        if hasattr(interaction_type, "value"):
+            interaction_type = interaction_type.value
         return WizardStepResponse(
             id=step.id,
             wizard_id=step.wizard_id,
             step_order=step.step_order,
-            interaction_type=step.interaction_type.value,
+            interaction_type=interaction_type,
             title=step.title,
             content_markdown=step.content_markdown,
             config=step.config,

--- a/backend/src/zondarr/api/wizards.py
+++ b/backend/src/zondarr/api/wizards.py
@@ -537,11 +537,14 @@ class WizardController(Controller):
         Returns:
             WizardStepResponse.
         """
+        interaction_type = step.interaction_type
+        if hasattr(interaction_type, "value"):
+            interaction_type = interaction_type.value
         return WizardStepResponse(
             id=step.id,
             wizard_id=step.wizard_id,
             step_order=step.step_order,
-            interaction_type=step.interaction_type.value,
+            interaction_type=interaction_type,
             title=step.title,
             content_markdown=step.content_markdown,
             config=step.config,


### PR DESCRIPTION
## Summary

- Fix `AttributeError` when serializing wizard step `interaction_type` that may already be a string rather than an enum member. Both `InvitationController` and `WizardController` now check for a `.value` attribute before accessing it.
- Always assign `target_servers` and `allowed_libraries` on new invitations (even when empty) to prevent SQLAlchemy lazy-load attempts in async sessions.
- Eagerly refresh `pre_wizard` and `post_wizard` relationships after creating an invitation so they are available without additional queries.

## Test plan

- [ ] Create an invitation with pre/post wizards and verify the response includes wizard data without errors
- [ ] Retrieve wizard steps and confirm `interaction_type` serializes correctly regardless of whether the value is an enum or string
- [ ] Create an invitation without target servers or allowed libraries and verify no lazy-load exceptions occur