### PR TITLE
refactor: optimize dev_cli startup time

### DIFF
--- a/dev_cli/preflight.py
+++ b/dev_cli/preflight.py
@@ -162,10 +162,10 @@ def _get_current_db_revision(backend_dir: Path, /) -> str | None:
     conn = sqlite3.connect(str(db_path))
     try:
         cursor = conn.execute("SELECT version_num FROM alembic_version LIMIT 1")
-        row = cursor.fetchone()
+        row: tuple[str, ...] | None = cursor.fetchone()  # pyright: ignore[reportAny]  # sqlite3 returns Any
         if row is None:
             return None
-        return row[0]
+        return str(row[0])
     except sqlite3.OperationalError:
         return None
     finally:
@@ -236,8 +236,7 @@ def _check_backend_reachable(port: int, /) -> None:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         if sock.connect_ex(("127.0.0.1", port)) != 0:
             print_warn(
-                f"Backend is not running on port {port}"
-                " — API calls from the frontend will fail"
+                f"Backend is not running on port {port} — API calls from the frontend will fail"
             )
 
 


### PR DESCRIPTION
## Summary

- **Parallel process startup:** Backend and frontend dev servers now start concurrently instead of sequentially. Ready-waits remain ordered (backend first, then frontend) to catch failures early. Error paths stop all servers, not just the failed one.
- **Fast-path migration check:** Before spawning the Alembic subprocess, read the `alembic_version` table directly via stdlib `sqlite3` and parse migration files to determine the head revision. If the DB is already at head, skip the subprocess entirely. Any failure in the fast path falls through to running Alembic as before.
- **Exponential backoff for health check:** Poll with 0.1s initial delay and 1.5x backoff (capped at 0.5s) instead of fixed 0.5s intervals. Max attempts increased from 10 to 15 to maintain a similar total timeout budget.

## Test plan

- [x] Both servers start concurrently (PIDs appear back-to-back in output)
- [x] Fast-path prints "Database already at head" when DB is current
- [x] Health check passes on first attempt after backend ready
- [x] `--backend-only` starts only the backend with no health check
- [x] `--frontend-only` starts only the frontend with no migration check
- [x] Deleting `zondarr.db` falls through to Alembic subprocess and creates the DB
- [x] `ruff check` and `ruff format` pass