### PR TITLE
Fix: show only supported permission toggles per server type

### DIFF
--- a/frontend/src/lib/components/users/user-permissions-editor.svelte
+++ b/frontend/src/lib/components/users/user-permissions-editor.svelte
@@ -24,9 +24,22 @@ import { Label } from "$lib/components/ui/label";
 interface Props {
 	userId: string;
 	disabled?: boolean;
+	serverType?: string;
 }
 
-const { userId, disabled = false }: Props = $props();
+const { userId, disabled = false, serverType }: Props = $props();
+
+/** Permission keys supported by each server type. */
+const SUPPORTED_PERMISSIONS: Record<string, readonly string[]> = {
+	plex: ["can_download"],
+	jellyfin: ["can_download", "can_stream", "can_sync", "can_transcode"],
+};
+
+function isPermissionSupported(key: string): boolean {
+	if (!serverType) return true;
+	const supported = SUPPORTED_PERMISSIONS[serverType];
+	return supported ? supported.includes(key) : true;
+}
 
 // Permission states - start as undefined (unknown from server)
 let canStream = $state<boolean | undefined>(undefined);
@@ -169,7 +182,10 @@ function toggleTranscode() {
  * Check if any permission is loading.
  */
 const anyLoading = $derived(
-	loadingStream || loadingDownload || loadingSync || loadingTranscode,
+	(isPermissionSupported("can_stream") && loadingStream) ||
+		(isPermissionSupported("can_download") && loadingDownload) ||
+		(isPermissionSupported("can_sync") && loadingSync) ||
+		(isPermissionSupported("can_transcode") && loadingTranscode),
 );
 </script>
 
@@ -181,6 +197,7 @@ const anyLoading = $derived(
 
 	<div class="grid gap-4 sm:grid-cols-2">
 		<!-- Streaming Permission -->
+		{#if isPermissionSupported("can_stream")}
 		<div class="flex items-center justify-between gap-3 rounded-lg border border-cr-border bg-cr-bg p-3">
 			<div class="space-y-0.5">
 				<Label class="text-cr-text text-sm font-medium">Streaming</Label>
@@ -211,8 +228,10 @@ const anyLoading = $derived(
 				{/if}
 			</button>
 		</div>
+		{/if}
 
 		<!-- Download Permission -->
+		{#if isPermissionSupported("can_download")}
 		<div class="flex items-center justify-between gap-3 rounded-lg border border-cr-border bg-cr-bg p-3">
 			<div class="space-y-0.5">
 				<Label class="text-cr-text text-sm font-medium">Downloads</Label>
@@ -243,8 +262,10 @@ const anyLoading = $derived(
 				{/if}
 			</button>
 		</div>
+		{/if}
 
 		<!-- Sync Permission -->
+		{#if isPermissionSupported("can_sync")}
 		<div class="flex items-center justify-between gap-3 rounded-lg border border-cr-border bg-cr-bg p-3">
 			<div class="space-y-0.5">
 				<Label class="text-cr-text text-sm font-medium">Sync</Label>
@@ -275,8 +296,10 @@ const anyLoading = $derived(
 				{/if}
 			</button>
 		</div>
+		{/if}
 
 		<!-- Transcode Permission -->
+		{#if isPermissionSupported("can_transcode")}
 		<div class="flex items-center justify-between gap-3 rounded-lg border border-cr-border bg-cr-bg p-3">
 			<div class="space-y-0.5">
 				<Label class="text-cr-text text-sm font-medium">Transcoding</Label>
@@ -307,5 +330,6 @@ const anyLoading = $derived(
 				{/if}
 			</button>
 		</div>
+		{/if}
 	</div>
 </div>

--- a/frontend/src/routes/(admin)/users/[id]/+page.svelte
+++ b/frontend/src/routes/(admin)/users/[id]/+page.svelte
@@ -352,6 +352,7 @@ function viewLinkedUser(userId: string) {
 					<UserPermissionsEditor
 						userId={data.user.id}
 						disabled={!data.user.enabled || enabling || disabling || deleting}
+						serverType={data.user.media_server.server_type}
 					/>
 				</Card.Content>
 			</Card.Root>


### PR DESCRIPTION
## Summary

- Filter permission toggles on the user detail page based on the media server type. Plex only supports the download permission, while Jellyfin supports download, stream, sync, and transcode.
- Pass `serverType` from the user's media server into `UserPermissionsEditor` so it can conditionally render only the relevant toggles.
- Adjust the `anyLoading` derived state to ignore loading flags for unsupported permissions.

## Test plan

- [ ] Navigate to a Plex user's detail page and verify only the "Downloads" toggle is shown.
- [ ] Navigate to a Jellyfin user's detail page and verify all four permission toggles are shown.
- [ ] Confirm toggling permissions still works correctly for both server types.