### PR TITLE
refactor: make permission capabilities provider-agnostic

### DIFF
--- a/backend/src/zondarr/api/invitations.py
+++ b/backend/src/zondarr/api/invitations.py
@@ -23,6 +23,7 @@ from litestar.status_codes import HTTP_201_CREATED, HTTP_204_NO_CONTENT
 from litestar.types import AnyCallable
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from zondarr.media.registry import registry
 from zondarr.models.invitation import Invitation
 from zondarr.models.wizard import Wizard, WizardStep
 from zondarr.repositories.invitation import InvitationRepository
@@ -393,6 +394,9 @@ class InvitationController(Controller):
                 enabled=server.enabled,
                 created_at=server.created_at,
                 updated_at=server.updated_at,
+                supported_permissions=sorted(
+                    registry.get_supported_permissions(server.server_type)
+                ),
             )
             for server in invitation.target_servers
         ]
@@ -476,6 +480,9 @@ class InvitationController(Controller):
                 enabled=server.enabled,
                 created_at=server.created_at,
                 updated_at=server.updated_at,
+                supported_permissions=sorted(
+                    registry.get_supported_permissions(server.server_type)
+                ),
             )
             for server in invitation.target_servers
         ]

--- a/backend/src/zondarr/api/schemas.py
+++ b/backend/src/zondarr/api/schemas.py
@@ -176,6 +176,7 @@ class MediaServerResponse(msgspec.Struct, omit_defaults=True):
     enabled: bool
     created_at: datetime
     updated_at: datetime | None = None
+    supported_permissions: list[str] | None = None
 
 
 # =============================================================================
@@ -225,6 +226,7 @@ class MediaServerWithLibrariesResponse(msgspec.Struct, omit_defaults=True):
     created_at: datetime
     libraries: list[LibraryResponse]
     updated_at: datetime | None = None
+    supported_permissions: list[str] | None = None
 
 
 # =============================================================================

--- a/backend/src/zondarr/api/servers.py
+++ b/backend/src/zondarr/api/servers.py
@@ -24,6 +24,7 @@ from litestar.types import AnyCallable
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from zondarr.media.exceptions import MediaClientError
+from zondarr.media.registry import registry
 from zondarr.models.media_server import ServerType
 from zondarr.repositories.identity import IdentityRepository
 from zondarr.repositories.media_server import MediaServerRepository
@@ -194,6 +195,9 @@ class ServerController(Controller):
                     )
                     for lib in server.libraries
                 ],
+                supported_permissions=sorted(
+                    registry.get_supported_permissions(server.server_type)
+                ),
             )
             for server in servers
         ]
@@ -265,6 +269,9 @@ class ServerController(Controller):
             created_at=server.created_at,
             updated_at=server.updated_at,
             libraries=libraries,
+            supported_permissions=sorted(
+                registry.get_supported_permissions(server.server_type)
+            ),
         )
 
     @get(
@@ -302,6 +309,9 @@ class ServerController(Controller):
             enabled=server.enabled,
             created_at=server.created_at,
             updated_at=server.updated_at,
+            supported_permissions=sorted(
+                registry.get_supported_permissions(server.server_type)
+            ),
         )
 
     @delete(

--- a/backend/src/zondarr/api/users.py
+++ b/backend/src/zondarr/api/users.py
@@ -22,6 +22,7 @@ from litestar.params import Parameter
 from litestar.types import AnyCallable
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from zondarr.media.registry import registry
 from zondarr.models.identity import User
 from zondarr.repositories.identity import IdentityRepository
 from zondarr.repositories.user import UserRepository
@@ -426,6 +427,9 @@ class UserController(Controller):
             enabled=user.media_server.enabled,
             created_at=user.media_server.created_at,
             updated_at=user.media_server.updated_at,
+            supported_permissions=sorted(
+                registry.get_supported_permissions(user.media_server.server_type)
+            ),
         )
 
         # Build invitation response if available (Requirement 17.3)

--- a/backend/src/zondarr/media/clients/jellyfin.py
+++ b/backend/src/zondarr/media/clients/jellyfin.py
@@ -135,6 +135,10 @@ class JellyfinClient:
             Capability.DOWNLOAD_PERMISSION,
         }
 
+    @classmethod
+    def supported_permissions(cls) -> frozenset[str]:
+        return frozenset({"can_download", "can_stream", "can_sync", "can_transcode"})
+
     async def __aenter__(self) -> Self:
         """Enter async context, establishing connection.
 

--- a/backend/src/zondarr/media/clients/plex.py
+++ b/backend/src/zondarr/media/clients/plex.py
@@ -246,6 +246,10 @@ class PlexClient:
             Capability.LIBRARY_ACCESS,
         }
 
+    @classmethod
+    def supported_permissions(cls) -> frozenset[str]:
+        return frozenset({"can_download"})
+
     async def __aenter__(self) -> Self:
         """Enter async context, establishing connection.
 

--- a/backend/src/zondarr/media/protocol.py
+++ b/backend/src/zondarr/media/protocol.py
@@ -56,6 +56,20 @@ class MediaClient(Protocol):
         """
         ...
 
+    @classmethod
+    def supported_permissions(cls) -> frozenset[str]:
+        """Return the set of universal permission keys this client supports.
+
+        Used to inform the frontend which permission toggles to display
+        for a given server type, without hardcoding provider knowledge
+        in the UI.
+
+        Returns:
+            A frozenset of universal permission key strings
+            (e.g. "can_download", "can_stream").
+        """
+        ...
+
     async def __aenter__(self) -> Self:
         """Enter async context, establishing connection.
 

--- a/backend/src/zondarr/media/registry.py
+++ b/backend/src/zondarr/media/registry.py
@@ -71,6 +71,11 @@ class MediaClientClass(Protocol):
         """Return the set of capabilities this client supports."""
         ...
 
+    @classmethod
+    def supported_permissions(cls) -> frozenset[str]:
+        """Return the set of universal permission keys this client supports."""
+        ...
+
 
 class ClientRegistry:
     """Singleton registry for media client implementations.
@@ -159,6 +164,23 @@ class ClientRegistry:
             UnknownServerTypeError: If no client is registered for the server type.
         """
         return self.get_client_class(server_type).capabilities()
+
+    def get_supported_permissions(self, server_type: ServerType, /) -> frozenset[str]:
+        """Get supported permissions for a server type.
+
+        Queries the registered client class for its declared
+        supported permission keys.
+
+        Args:
+            server_type: The server type to query (positional-only).
+
+        Returns:
+            A frozenset of permission key strings.
+
+        Raises:
+            UnknownServerTypeError: If no client is registered for the server type.
+        """
+        return self.get_client_class(server_type).supported_permissions()
 
     def create_client(
         self,

--- a/frontend/src/lib/api/types.d.ts
+++ b/frontend/src/lib/api/types.d.ts
@@ -561,6 +561,7 @@ export interface components {
 			/** Format: date-time */
 			created_at: string;
 			updated_at?: string | null;
+			supported_permissions?: string[] | null;
 		};
 		/** MediaServerWithLibrariesResponse */
 		MediaServerWithLibrariesResponse: {
@@ -574,6 +575,7 @@ export interface components {
 			created_at: string;
 			libraries: components['schemas']['LibraryResponse'][];
 			updated_at?: string | null;
+			supported_permissions?: string[] | null;
 		};
 		/** PlexOAuthCheckResponse */
 		PlexOAuthCheckResponse: {

--- a/frontend/src/lib/components/users/user-permissions-editor.svelte
+++ b/frontend/src/lib/components/users/user-permissions-editor.svelte
@@ -24,21 +24,14 @@ import { Label } from "$lib/components/ui/label";
 interface Props {
 	userId: string;
 	disabled?: boolean;
-	serverType?: string;
+	supportedPermissions?: string[];
 }
 
-const { userId, disabled = false, serverType }: Props = $props();
-
-/** Permission keys supported by each server type. */
-const SUPPORTED_PERMISSIONS: Record<string, readonly string[]> = {
-	plex: ["can_download"],
-	jellyfin: ["can_download", "can_stream", "can_sync", "can_transcode"],
-};
+const { userId, disabled = false, supportedPermissions }: Props = $props();
 
 function isPermissionSupported(key: string): boolean {
-	if (!serverType) return true;
-	const supported = SUPPORTED_PERMISSIONS[serverType];
-	return supported ? supported.includes(key) : true;
+	if (!supportedPermissions) return true;
+	return supportedPermissions.includes(key);
 }
 
 // Permission states - start as undefined (unknown from server)

--- a/frontend/src/routes/(admin)/users/[id]/+page.svelte
+++ b/frontend/src/routes/(admin)/users/[id]/+page.svelte
@@ -352,7 +352,7 @@ function viewLinkedUser(userId: string) {
 					<UserPermissionsEditor
 						userId={data.user.id}
 						disabled={!data.user.enabled || enabling || disabling || deleting}
-						serverType={data.user.media_server.server_type}
+						supportedPermissions={data.user.media_server.supported_permissions ?? undefined}
 					/>
 				</Card.Content>
 			</Card.Root>


### PR DESCRIPTION
## Summary

- Moves hardcoded permission-per-server-type mappings from the frontend into the backend by adding a `supported_permissions()` classmethod to the `MediaClient` protocol and each concrete client (Plex, Jellyfin)
- Exposes `supported_permissions` on server response schemas so the frontend dynamically renders only the relevant permission toggles based on backend data
- Removes the static `SUPPORTED_PERMISSIONS` lookup table from `user-permissions-editor.svelte`, replacing it with the server-provided list

## Test plan

- [ ] Verify the user detail page shows only `can_download` for Plex servers
- [ ] Verify the user detail page shows `can_download`, `can_stream`, `can_sync`, and `can_transcode` for Jellyfin servers
- [ ] Confirm invitation and server list endpoints include `supported_permissions` in their responses
- [ ] Check that adding a new server type in the future only requires implementing `supported_permissions()` on the client class with no frontend changes