### PR TITLE
Fix dialog buttons becoming unresponsive after SPA navigation

### DIFF
--- a/frontend/src/lib/components/confirm-dialog.svelte
+++ b/frontend/src/lib/components/confirm-dialog.svelte
@@ -64,7 +64,6 @@ function handleOpenChange(isOpen: boolean) {
 	if (!isOpen && !loading) {
 		onCancel();
 	}
-	open = isOpen;
 }
 </script>
 

--- a/frontend/src/lib/components/invitations/create-invitation-dialog.svelte
+++ b/frontend/src/lib/components/invitations/create-invitation-dialog.svelte
@@ -39,6 +39,15 @@ const { servers, onSuccess }: Props = $props();
 // Dialog open state
 let open = $state(false);
 
+// Fetch wizards when dialog opens, reset form when it closes
+$effect(() => {
+	if (open) {
+		fetchWizards();
+	} else {
+		resetForm();
+	}
+});
+
 // Submitting state
 let submitting = $state(false);
 
@@ -150,9 +159,8 @@ async function handleSubmit() {
 			`Code: ${result.data?.code}`,
 		);
 
-		// Close dialog and reset form
+		// Close dialog (form resets via $effect watching open)
 		open = false;
-		resetForm();
 
 		// Notify parent to refresh list
 		onSuccess?.();
@@ -162,27 +170,14 @@ async function handleSubmit() {
 }
 
 /**
- * Handle dialog close.
- */
-function handleOpenChange(isOpen: boolean) {
-	open = isOpen;
-	if (isOpen) {
-		fetchWizards();
-	} else {
-		resetForm();
-	}
-}
-
-/**
  * Handle cancel button.
  */
 function handleCancel() {
 	open = false;
-	resetForm();
 }
 </script>
 
-<Dialog.Root bind:open onOpenChange={handleOpenChange}>
+<Dialog.Root bind:open>
 	<Dialog.Trigger>
 		{#snippet child({ props })}
 			<Button

--- a/frontend/src/lib/components/servers/create-server-dialog.svelte
+++ b/frontend/src/lib/components/servers/create-server-dialog.svelte
@@ -37,6 +37,13 @@ const providerList = $derived(getAllProviders());
 // Dialog open state
 let open = $state(false);
 
+// Reset form when dialog closes
+$effect(() => {
+	if (!open) {
+		resetForm();
+	}
+});
+
 // Submitting state
 let submitting = $state(false);
 
@@ -131,9 +138,8 @@ async function handleSubmit(event: Event) {
 			`${result.data?.name} has been configured`,
 		);
 
-		// Close dialog and reset form
+		// Close dialog (form resets via $effect watching open)
 		open = false;
-		resetForm();
 
 		// Notify parent to refresh list
 		onSuccess?.();
@@ -143,25 +149,14 @@ async function handleSubmit(event: Event) {
 }
 
 /**
- * Handle dialog close.
- */
-function handleOpenChange(isOpen: boolean) {
-	open = isOpen;
-	if (!isOpen) {
-		resetForm();
-	}
-}
-
-/**
  * Handle cancel button.
  */
 function handleCancel() {
 	open = false;
-	resetForm();
 }
 </script>
 
-<Dialog.Root bind:open onOpenChange={handleOpenChange}>
+<Dialog.Root bind:open>
 	<Dialog.Trigger>
 		{#snippet child({ props })}
 			<Button

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -11,9 +11,7 @@ import type { LayoutData } from "./$types";
 const { data, children }: { data: LayoutData; children: Snippet } = $props();
 
 $effect(() => {
-	if (data.providers.length > 0) {
-		setProviders(data.providers);
-	}
+	setProviders(data.providers);
 });
 </script>
 


### PR DESCRIPTION
## Summary

- Resolved a conflict between `bind:open` and `onOpenChange` in bits-ui Dialog components that caused trigger buttons to stop responding after client-side navigation
- Replaced manual `onOpenChange` callbacks with `$effect()` blocks that reactively watch the `open` state, eliminating the dual-write conflict
- Fixed `setProviders` in the root layout to always run regardless of array length, preventing stale provider state after navigation

## Context

When using `bind:open` together with an `onOpenChange` handler on bits-ui `Dialog.Root`, both attempt to control the same `open` state. After SPA navigation re-renders the component, this conflict causes the dialog trigger to silently fail. The fix removes the `onOpenChange` handler entirely and moves side effects (form reset, wizard fetching) into reactive `$effect()` blocks that respond to `open` state changes.

## Test plan

- [ ] Navigate between pages and verify dialog trigger buttons remain functional
- [ ] Open and close create-invitation and create-server dialogs, confirm forms reset on close
- [ ] Verify wizard list loads when opening the create-invitation dialog
- [ ] Confirm the confirm-dialog (e.g., delete actions) opens and closes correctly