### PR TITLE
Fix Add Server dialog: require connection test before submit, default to Plex

### DIFF
--- a/frontend/src/lib/components/servers/create-server-dialog.svelte
+++ b/frontend/src/lib/components/servers/create-server-dialog.svelte
@@ -175,7 +175,7 @@ async function handleTestConnection() {
 async function handleSubmit(event: Event) {
 	event.preventDefault();
 
-	if (!validateForm()) {
+	if (!connectionVerified || !validateForm()) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

- Require a successful connection test before the Add Server form can be submitted, preventing users from saving servers with invalid or untested credentials
- Default the server type selection to Plex instead of leaving it blank
- Reset the connection test result when the server name or server type changes, ensuring the test reflects the current form state

## Test plan

- [ ] Open the Add Server dialog and verify Plex is pre-selected
- [ ] Confirm the "Add Server" submit button is disabled until a connection test passes
- [ ] Fill in valid credentials, run a successful test, then verify submit becomes enabled
- [ ] Change the server type after a successful test and verify submit is disabled again until re-tested
- [ ] Change the server name after a successful test and verify submit is disabled again until re-tested