### PR TITLE
Fix create-server dialog reset on mount and improve layout

### DIFF
--- a/frontend/src/lib/components/servers/create-server-dialog.svelte
+++ b/frontend/src/lib/components/servers/create-server-dialog.svelte
@@ -40,10 +40,12 @@ const providerList = $derived(getAllProviders());
 let open = $state(false);
 
 // Reset form when dialog closes, fetch env credentials when it opens
+let hasBeenOpened = false;
 $effect(() => {
 	if (open) {
+		hasBeenOpened = true;
 		fetchEnvCredentials();
-	} else {
+	} else if (hasBeenOpened) {
 		resetForm();
 	}
 });
@@ -276,7 +278,7 @@ function handleCancel() {
 	</Dialog.Trigger>
 
 	<Dialog.Content
-		class="border-cr-border bg-cr-surface sm:max-w-md"
+		class="border-cr-border bg-cr-surface sm:max-w-lg max-h-[85dvh] overflow-y-auto"
 	>
 		<Dialog.Header>
 			<Dialog.Title class="text-cr-text flex items-center gap-2">
@@ -289,7 +291,7 @@ function handleCancel() {
 		</Dialog.Header>
 
 		{#if showEnvBanner}
-			<div class="mt-4 rounded-lg border border-cr-accent/30 bg-cr-accent/5 p-3">
+			<div class="rounded-lg border border-cr-accent/30 bg-cr-accent/5 p-3">
 				<div class="flex items-start justify-between gap-2">
 					<div class="flex items-center gap-2 text-sm font-medium text-cr-accent">
 						<Info class="size-4 shrink-0" />
@@ -329,7 +331,7 @@ function handleCancel() {
 			</div>
 		{/if}
 
-		<form onsubmit={handleSubmit} class="mt-4 space-y-4">
+		<form onsubmit={handleSubmit} class="space-y-4">
 			<!-- Server Name -->
 			<div class="space-y-2">
 				<Label for="name" class="text-cr-text">Server Name</Label>


### PR DESCRIPTION
## Summary

- Prevent `resetForm()` from firing on initial component mount by introducing a `hasBeenOpened` guard, so the form state is only reset when the dialog is actually closed after being opened.
- Widen the dialog from `sm:max-w-md` to `sm:max-w-lg` and add `max-h-[85dvh] overflow-y-auto` to ensure the content is scrollable on smaller viewports.
- Remove redundant `mt-4` margins on the env credentials banner and form to tighten up spacing.

## Test plan

- [ ] Open the page containing the Add Server dialog and confirm no unexpected form reset occurs on initial load
- [ ] Open and close the dialog, then reopen it to verify `resetForm()` fires correctly on close
- [ ] Resize the browser to a small viewport and confirm the dialog content scrolls properly
- [ ] Verify the env credentials banner and form spacing looks correct with no extra gaps