### PR TITLE
Fix wizard eager-loading failures and add delete button to wizard list

### DIFF
--- a/backend/src/zondarr/repositories/wizard.py
+++ b/backend/src/zondarr/repositories/wizard.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.sql import Select
 
 from zondarr.core.exceptions import RepositoryError
-from zondarr.models.wizard import Wizard
+from zondarr.models.wizard import Wizard, WizardStep
 from zondarr.repositories.base import Repository
 
 # Type alias for valid sort fields
@@ -58,7 +58,9 @@ class WizardRepository(Repository[Wizard]):
         try:
             result = await self.session.scalars(
                 select(Wizard)
-                .options(selectinload(Wizard.steps))
+                .options(
+                    selectinload(Wizard.steps).selectinload(WizardStep.interactions)
+                )
                 .where(Wizard.id == wizard_id)
             )
             return result.first()

--- a/backend/src/zondarr/services/wizard.py
+++ b/backend/src/zondarr/services/wizard.py
@@ -295,7 +295,9 @@ class WizardService:
         if content_markdown is not None:
             step.content_markdown = content_markdown
 
-        return await self.step_repo.update(step)
+        updated_step = await self.step_repo.update(step)
+        await self.step_repo.session.refresh(updated_step, ["interactions"])
+        return updated_step
 
     async def delete_step(self, wizard_id: UUID, step_id: UUID, /) -> None:
         """Delete a wizard step and normalize remaining step orders.
@@ -357,6 +359,7 @@ class WizardService:
         updated_step = await self.step_repo.get_by_id(step_id)
         if updated_step is None:
             raise NotFoundError("WizardStep", str(step_id))
+        await self.step_repo.session.refresh(updated_step, ["interactions"])
         return updated_step
 
     # ==================== Interaction CRUD ====================
@@ -465,7 +468,9 @@ class WizardService:
             )
             interaction.config = validated_config
 
-        return await self.interaction_repo.update(interaction)
+        updated = await self.interaction_repo.update(interaction)
+        await self.interaction_repo.session.refresh(updated, ["step"])
+        return updated
 
     async def remove_interaction(
         self,


### PR DESCRIPTION
## Summary

- Fix five endpoints that returned HTTP 500 due to SQLAlchemy `MissingGreenlet` errors when accessing `WizardStep.interactions` without eager-loading in async context
- Add nested `selectinload` for `WizardStep.interactions` in `get_with_steps()`, `update_step()`, `reorder_step()`, `update_interaction()`, and `get_by_code()` (invitation validation)
- Add delete button with confirmation dialog to the wizard list page, matching the existing invitation list pattern

## Affected endpoints

- `GET /api/v1/wizards/{id}` — eager-load interactions via repository
- `PATCH /api/v1/wizards/{id}/steps/{step_id}` — refresh interactions after update
- `POST /api/v1/wizards/{id}/steps/{step_id}/reorder` — refresh interactions after reorder
- `PATCH .../interactions/{interaction_id}` — refresh step relationship after update
- `GET /api/v1/invitations/validate/{code}` — eager-load wizard steps and interactions

## Test plan

- [x] All 26 wizard property tests pass
- [x] Full backend suite passes (299 tests)
- [x] Frontend type check passes (0 errors, 0 warnings)
- [x] All pre-push hooks pass (basedpyright, svelte-check, pytest, vitest)