### PR TITLE
Add copy invite link button to invitations pages

### DIFF
--- a/frontend/src/lib/components/invitations/invitation-row.svelte
+++ b/frontend/src/lib/components/invitations/invitation-row.svelte
@@ -14,6 +14,7 @@
  */
 
 import { Check, Copy, Eye, MoreHorizontal, Pencil, Trash2 } from "@lucide/svelte";
+import { onDestroy } from "svelte";
 import { toast } from "svelte-sonner";
 import { goto } from "$app/navigation";
 import type { InvitationResponse } from "$lib/api/client";
@@ -136,6 +137,11 @@ function handleEdit() {
 }
 
 let copied = $state(false);
+let copiedTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+onDestroy(() => {
+	if (copiedTimeoutId) clearTimeout(copiedTimeoutId);
+});
 
 /**
  * Copy the invite link to clipboard.
@@ -146,7 +152,8 @@ async function copyInviteLink() {
 		await navigator.clipboard.writeText(url);
 		copied = true;
 		showSuccess("Invite link copied");
-		setTimeout(() => { copied = false; }, 2000);
+		if (copiedTimeoutId) clearTimeout(copiedTimeoutId);
+		copiedTimeoutId = setTimeout(() => { copied = false; }, 2000);
 	} catch {
 		showError("Failed to copy invite link");
 	}

--- a/frontend/src/routes/(admin)/invitations/[id]/+page.svelte
+++ b/frontend/src/routes/(admin)/invitations/[id]/+page.svelte
@@ -26,6 +26,7 @@ import {
 	Users,
 	Wand2,
 } from "@lucide/svelte";
+import { onDestroy } from "svelte";
 import { goto, invalidateAll } from "$app/navigation";
 import {
 	deleteInvitation,
@@ -104,6 +105,11 @@ let showDeleteDialog = $state(false);
 
 // Copy link state
 let copied = $state(false);
+let copiedTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+onDestroy(() => {
+	if (copiedTimeoutId) clearTimeout(copiedTimeoutId);
+});
 
 /**
  * Copy the invite link to clipboard.
@@ -115,7 +121,8 @@ async function copyInviteLink() {
 		await navigator.clipboard.writeText(url);
 		copied = true;
 		showSuccess("Invite link copied");
-		setTimeout(() => { copied = false; }, 2000);
+		if (copiedTimeoutId) clearTimeout(copiedTimeoutId);
+		copiedTimeoutId = setTimeout(() => { copied = false; }, 2000);
 	} catch {
 		showError("Failed to copy invite link");
 	}


### PR DESCRIPTION
## Summary

- Add a "Copy Invite Link" button to the invitation row actions toolbar on the invitations list page
- Add a "Copy Invite Link" button to the invitation detail page header
- Both buttons copy the shareable URL (`{origin}/join/{code}`) to the clipboard, show a success toast, and briefly display a checkmark icon

## Test plan

- [ ] Navigate to `/invitations` and verify the copy button appears in each row's action toolbar
- [ ] Click the copy button and confirm the correct URL is copied to the clipboard
- [ ] Navigate to `/invitations/{id}` and verify the "Copy Invite Link" button appears in the header
- [ ] Click the button and confirm the URL is copied, toast appears, and icon changes to a checkmark for 2 seconds