### PR TITLE
Fix join page layout gap and remove footer

### DIFF
--- a/frontend/src/routes/(public)/+layout.svelte
+++ b/frontend/src/routes/(public)/+layout.svelte
@@ -29,14 +29,9 @@ const { children }: Props = $props();
 	</header>
 
 	<!-- Main content area -->
-	<main class="flex flex-1 flex-col items-center justify-center px-4 py-8 md:py-12">
+	<main class="flex flex-1 flex-col items-center px-4 py-8 md:py-12">
 		<div class="w-full max-w-lg">
 			{@render children()}
 		</div>
 	</main>
-
-	<!-- Minimal footer -->
-	<footer class="border-t border-cr-border bg-cr-bg px-4 py-4 text-center text-sm text-cr-text-muted">
-		<p>Powered by Zondarr</p>
-	</footer>
 </div>


### PR DESCRIPTION
## Summary
- Remove `justify-center` from public layout main content area to eliminate the excessive vertical gap between the header and page title on the join/onboarding page
- Remove the "Powered by Zondarr" footer element entirely from the public layout

## Test plan
- [x] Verified visually via Chrome DevTools screenshots before and after
- [x] All pre-commit and pre-push hooks pass (Biome, svelte-check, vitest)