### PR TITLE
Fix SSE log stream 404 by using API base URL

### DIFF
--- a/frontend/src/lib/stores/log-stream.svelte.ts
+++ b/frontend/src/lib/stores/log-stream.svelte.ts
@@ -7,6 +7,8 @@
  * @module $lib/stores/log-stream
  */
 
+import { env } from '$env/dynamic/public';
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -52,8 +54,8 @@ let _eventSource: EventSource | null = null;
 export function connect(): void {
 	if (_eventSource) return;
 
-	// Use same-origin by default (SvelteKit proxy or direct)
-	const url = '/api/v1/logs/stream';
+	const API_BASE_URL = env.PUBLIC_API_URL ?? '';
+	const url = `${API_BASE_URL}/api/v1/logs/stream`;
 
 	const es = new EventSource(url, { withCredentials: true });
 	_eventSource = es;


### PR DESCRIPTION
## Summary

- The `/logs` page EventSource connected to a relative URL (`/api/v1/logs/stream`), which resolved to the Vite dev server (`localhost:5173`) instead of the backend (`localhost:8000`), returning a 404.
- Prepend `PUBLIC_API_URL` to the SSE endpoint URL, matching the pattern used by the `openapi-fetch` client in `client.ts`.
- In production (same-origin), `PUBLIC_API_URL` is empty, so behavior is unchanged.

## Test plan

- [x] `bun run check` passes with no errors
- [x] `bun run test` passes (293 tests)
- [ ] `uv run dev_cli --skip-auth` and open `http://localhost:5173/logs` -- log entries stream in, status shows "Live"
- [ ] No 404 errors in browser console for `/api/v1/logs/stream`