### PR TITLE
fix(wizard): prevent Add Option from resetting quiz editor state

### DIFF
--- a/frontend/src/lib/components/wizard/interactions/config-editors/quiz-config-editor.svelte
+++ b/frontend/src/lib/components/wizard/interactions/config-editors/quiz-config-editor.svelte
@@ -8,12 +8,9 @@ import { Button } from "$lib/components/ui/button";
 import { Input } from "$lib/components/ui/input";
 import { Label } from "$lib/components/ui/label";
 import * as RadioGroup from "$lib/components/ui/radio-group";
-import { quizConfigSchema } from "$lib/schemas/wizard";
 import type { ConfigEditorProps } from "../registry";
 
 const { config: rawConfig, onConfigChange, errors }: ConfigEditorProps = $props();
-
-const config = $derived(quizConfigSchema.safeParse(rawConfig).data);
 
 function updateField(field: string, value: unknown) {
 	onConfigChange({ ...rawConfig, [field]: value });
@@ -46,7 +43,7 @@ function updateOption(index: number, value: string) {
 		<Label for="question" class="text-cr-text">Question</Label>
 		<Input
 			id="question"
-			value={config?.question ?? ''}
+			value={(rawConfig.question as string) ?? ''}
 			oninput={(e) => updateField('question', e.currentTarget.value)}
 			placeholder="Enter your question"
 			class="border-cr-border bg-cr-bg text-cr-text"
@@ -63,7 +60,7 @@ function updateOption(index: number, value: string) {
 				variant="outline"
 				size="sm"
 				onclick={addOption}
-				disabled={(config?.options?.length ?? 0) >= 10}
+				disabled={((rawConfig.options as string[] | undefined)?.length ?? 0) >= 10}
 				class="border-cr-border text-cr-text-muted"
 			>
 				Add Option
@@ -71,11 +68,11 @@ function updateOption(index: number, value: string) {
 		</div>
 
 		<RadioGroup.Root
-			value={String(config?.correct_answer_index ?? 0)}
+			value={String(rawConfig.correct_answer_index ?? 0)}
 			onValueChange={(val) => updateField('correct_answer_index', parseInt(val))}
 			class="flex flex-col gap-2"
 		>
-			{#each config?.options ?? [] as option, index}
+			{#each (rawConfig.options as string[]) ?? [] as option, index}
 				<div class="flex items-center gap-2">
 					<div class="flex items-center justify-center w-8 shrink-0">
 						<RadioGroup.Item value={String(index)} />
@@ -90,7 +87,7 @@ function updateOption(index: number, value: string) {
 						variant="ghost"
 						size="sm"
 						onclick={() => removeOption(index)}
-						disabled={(config?.options?.length ?? 0) <= 2}
+						disabled={((rawConfig.options as string[] | undefined)?.length ?? 0) <= 2}
 						class="text-cr-text-muted hover:text-destructive"
 					>
 						×

--- a/frontend/src/lib/components/wizard/interactions/config-editors/text-input-config-editor.svelte
+++ b/frontend/src/lib/components/wizard/interactions/config-editors/text-input-config-editor.svelte
@@ -7,12 +7,9 @@
 import { Input } from "$lib/components/ui/input";
 import { Label } from "$lib/components/ui/label";
 import { Switch } from "$lib/components/ui/switch";
-import { textInputConfigSchema } from "$lib/schemas/wizard";
 import type { ConfigEditorProps } from "../registry";
 
 const { config: rawConfig, onConfigChange, errors }: ConfigEditorProps = $props();
-
-const config = $derived(textInputConfigSchema.safeParse(rawConfig).data);
 
 function updateField(field: string, value: string | number | boolean | null) {
 	onConfigChange({ ...rawConfig, [field]: value });
@@ -24,7 +21,7 @@ function updateField(field: string, value: string | number | boolean | null) {
 		<Label for="input-label" class="text-cr-text">Input Label</Label>
 		<Input
 			id="input-label"
-			value={config?.label ?? ''}
+			value={(rawConfig.label as string) ?? ''}
 			oninput={(e) => updateField('label', e.currentTarget.value)}
 			placeholder="Your response"
 			class="border-cr-border bg-cr-bg text-cr-text"
@@ -38,7 +35,7 @@ function updateField(field: string, value: string | number | boolean | null) {
 		<Label for="input-placeholder" class="text-cr-text">Placeholder</Label>
 		<Input
 			id="input-placeholder"
-			value={config?.placeholder ?? ''}
+			value={(rawConfig.placeholder as string) ?? ''}
 			oninput={(e) => updateField('placeholder', e.currentTarget.value)}
 			placeholder="Enter placeholder text"
 			class="border-cr-border bg-cr-bg text-cr-text"
@@ -52,7 +49,7 @@ function updateField(field: string, value: string | number | boolean | null) {
 				id="min-length"
 				type="number"
 				min="0"
-				value={config?.min_length ?? ''}
+				value={rawConfig.min_length ?? ''}
 				oninput={(e) =>
 					updateField('min_length', e.currentTarget.value ? parseInt(e.currentTarget.value) : null)}
 				placeholder="0"
@@ -69,7 +66,7 @@ function updateField(field: string, value: string | number | boolean | null) {
 				id="max-length"
 				type="number"
 				min="1"
-				value={config?.max_length ?? ''}
+				value={rawConfig.max_length ?? ''}
 				oninput={(e) =>
 					updateField('max_length', e.currentTarget.value ? parseInt(e.currentTarget.value) : null)}
 				placeholder="No limit"
@@ -83,7 +80,7 @@ function updateField(field: string, value: string | number | boolean | null) {
 
 	<div class="flex items-center gap-2">
 		<Switch
-			checked={config?.required ?? true}
+			checked={(rawConfig.required as boolean) ?? true}
 			onCheckedChange={(checked) => updateField('required', checked)}
 		/>
 		<Label class="text-cr-text cursor-pointer">Required field</Label>


### PR DESCRIPTION
## Summary

- Fix quiz config editor "Add Option" button wiping all form state (question text, option values, correct answer selection)
- Apply the same fix to text-input config editor to prevent the same latent bug when clearing the label field

## Root cause

Config editor components derived display values from `safeParse().data`, which returns `undefined` whenever validation fails. Since `addOption()` appends an empty string that violates `z.string().min(1)`, the entire parsed config became `undefined` and all template bindings fell back to empty/default values.

## Fix

Remove the redundant `safeParse`-based `config` derived from both config editors and bind templates directly to `rawConfig`. Validation is already handled by the parent `step-editor.svelte`, so the per-editor validation was purely destructive.

## Test plan

- [x] `bun run check` passes (0 errors, 0 warnings)
- [x] `bun run test` passes (293 tests)
- [x] `bunx prek run --all-files` passes
- [ ] Manual: create wizard, add quiz step, fill question and options, click "Add Option" -- confirm state is preserved
- [ ] Manual: verify text-input, click, timer, and ToS interaction types still work correctly