### PR TITLE
fix(wizard): resolve silent failure when deleting wizard steps

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -24,10 +24,7 @@ const API_BASE_URL = env.PUBLIC_API_URL ?? '';
  */
 export const api = createClient<paths>({
 	baseUrl: API_BASE_URL,
-	credentials: 'include',
-	headers: {
-		'Content-Type': 'application/json'
-	}
+	credentials: 'include'
 });
 
 /**
@@ -38,9 +35,6 @@ export function createScopedClient(customFetch: typeof globalThis.fetch): ApiCli
 	return createClient<paths>({
 		baseUrl: API_BASE_URL,
 		credentials: 'include',
-		headers: {
-			'Content-Type': 'application/json'
-		},
 		fetch: customFetch
 	});
 }


### PR DESCRIPTION
## Summary

- Removed the global `Content-Type: application/json` header from the openapi-fetch client configuration in `frontend/src/lib/api/client.ts`.
- This header forced CORS preflight (OPTIONS) on bodyless requests like DELETE, which prevented wizard step deletion from reaching the backend.
- `openapi-fetch` already sets `Content-Type` automatically when a request body is present, making the global header redundant for POST/PATCH/PUT and harmful for DELETE/GET.

## Test plan

- [x] Verified DELETE request to `/api/v1/wizards/.../steps/...` returns 204 in browser Network tab
- [x] Verified deleted step disappears from UI and stays gone after page reload
- [x] Backend tests pass (372 passed)
- [x] Frontend tests pass (293 passed)
- [x] Pre-push hooks pass (TypeScript check, Biome lint, frontend tests)