### PR TITLE
fix(setup): resolve onboarding flow skipped on clean Docker run

### DIFF
--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -70,7 +70,18 @@ export async function getAuthMethods(
 	const response = await customFetch(`${API_BASE_URL}/api/auth/methods`, {
 		credentials: 'include'
 	});
-	return response.json() as Promise<AuthMethodsResponse>;
+	if (!response.ok) {
+		throw new Error(`Auth methods request failed (${response.status})`);
+	}
+	const data: unknown = await response.json();
+	if (
+		data == null ||
+		typeof data !== 'object' ||
+		typeof (data as Record<string, unknown>).setup_required !== 'boolean'
+	) {
+		throw new Error('Invalid auth methods response');
+	}
+	return data as AuthMethodsResponse;
 }
 
 export async function setupAdmin(


### PR DESCRIPTION
## Summary

- Buffer non-SSE responses in the SvelteKit API proxy to prevent `ReadableStream` body consumption during SSR cloning under Bun's JSC runtime
- Add `response.ok` check and shape validation to `getAuthMethods()`, matching the pattern used by all other auth API functions

## Problem

On a fresh Docker run (empty database), the app renders the login form instead of redirecting to `/setup`. The backend correctly returns `setup_required: true`, but the SvelteKit proxy passes `response.body` (a `ReadableStream`) directly into `new Response()`. During SSR, SvelteKit's internal fetch consumes the stream, and under Bun the body becomes empty after cloning. `response.json()` then resolves to `undefined`, causing a TypeError when the login loader accesses `.setup_required`. The error is caught and misclassified as a non-network error, rendering the login form with `backendAvailable: true`.

## Changes

**`frontend/src/routes/api/[...path]/+server.ts`**
- Buffer non-SSE proxy responses via `arrayBuffer()` before constructing the `Response`
- SSE (`text/event-stream`) responses continue streaming for real-time log support

**`frontend/src/lib/api/auth.ts`**
- Check `response.ok` before parsing JSON (previously the only auth function without this check)
- Validate the parsed response contains `setup_required` as a boolean
- Throw descriptive errors on failure, caught by existing loader error handling

## Test plan

- [ ] `bun run check` passes with zero type errors
- [ ] `bun run test` passes all 294 tests
- [ ] Normal login flow works (proxy still forwards correctly)
- [ ] Fresh database start redirects to `/setup` instead of showing login
- [ ] Log streaming via SSE continues to work after login