### PR TITLE
fix(hooks): add /api and /health to PUBLIC_PATHS to prevent 302 redirect

### DIFF
--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -5,7 +5,7 @@ import { env as publicEnv } from '$env/dynamic/public';
 
 const SSR_API_URL = env.INTERNAL_API_URL ?? publicEnv.PUBLIC_API_URL ?? 'http://localhost:8000';
 
-const PUBLIC_PATHS = ['/login', '/setup', '/join'];
+const PUBLIC_PATHS = ['/login', '/setup', '/join', '/api', '/health'];
 
 function isPublicPath(pathname: string): boolean {
 	return PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));


### PR DESCRIPTION
## Summary

- Add `/api` and `/health` to `PUBLIC_PATHS` in `hooks.server.ts` so the frontend's page-level auth guard no longer intercepts these routes with a 302 redirect to `/login`.

## Problem

On a clean Docker install, the onboarding wizard was skipped entirely. The `handle` hook in `hooks.server.ts` redirected unauthenticated SSR requests to `/api/auth/methods` with a 302 because `/api` was not in `PUBLIC_PATHS`. This prevented `getAuthMethods()` from reading the `setup_required` flag, so the app never routed to `/setup`.

PR #65 solved CORS blocking via the API proxy but did not add `/api` to public paths. PR #66 fixed response body buffering but the 302 redirect occurs before the proxy handler runs.

## Fix

One-line change: add `/api` and `/health` to the `PUBLIC_PATHS` array. API routes handle their own authentication via the backend's JWT middleware and should not be subject to the frontend's page-level auth guard. Health endpoints should always be accessible.

## Test plan

- [ ] Clean Docker install (delete `zondarr.db`, restart container): app redirects to `/setup` on first visit
- [ ] No `Auth methods request failed (302)` errors in Docker logs
- [ ] After completing setup, login page loads and functions correctly
- [ ] After logging in, `/api/*` routes remain accessible
- [ ] Unauthenticated users are still redirected to `/login` for page routes (e.g., `/dashboard`)