### PR TITLE
Fix logs page crash during sidebar navigation

### DIFF
--- a/frontend/src/lib/components/logs/log-toolbar.svelte
+++ b/frontend/src/lib/components/logs/log-toolbar.svelte
@@ -93,7 +93,7 @@ const hasActiveFilters = $derived(
 );
 
 // Debounced search
-let searchInput: HTMLInputElement | undefined = $state();
+let searchInput: HTMLInputElement | null = $state(null);
 let internalSearch = $state("");
 let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 


### PR DESCRIPTION
## Summary

- Fixed a Svelte 5 runtime crash that prevented the Logs page from rendering when navigating via the sidebar (e.g., Dashboard -> Settings -> Logs)

## Root Cause

In `log-toolbar.svelte`, the `searchInput` variable was initialized as `$state()` (undefined), but the `Input` component's `ref` prop declares a fallback of `$bindable(null)`. Svelte 5 throws a `props_invalid_value` error when `bind:ref` receives `undefined` for a prop with a fallback value. This crashed the Logs page during component mount, leaving the previous page's content visible instead.

## Changes

- `frontend/src/lib/components/logs/log-toolbar.svelte`: Changed `searchInput` initialization from `$state()` to `$state(null)` with the corresponding type update from `HTMLInputElement | undefined` to `HTMLInputElement | null`

## Test plan

- [ ] Navigate Dashboard -> Settings -> Logs and confirm the Logs page renders correctly with SSE stream active
- [ ] Navigate Logs -> Settings -> Dashboard (reverse) and confirm all pages load
- [ ] Verify no console errors during sidebar navigation
- [ ] `bun run check` passes with 0 errors
- [ ] `bun run test` passes (304 tests across 28 files)