### PR TITLE
Fix TOTP QR code generation ValueError

### DIFF
--- a/backend/src/zondarr/services/totp.py
+++ b/backend/src/zondarr/services/totp.py
@@ -211,7 +211,7 @@ class TOTPService:
         qr = segno.make(uri)
         svg_buffer = io.BytesIO()
         qr.save(
-            svg_buffer, kind="svg", scale=4, dark="currentColor", light="transparent"
+            svg_buffer, kind="svg", scale=4, dark="#000000", light=None
         )
         qr_svg = svg_buffer.getvalue().decode()
 


### PR DESCRIPTION
## Summary

- Fix `ValueError` in `POST /api/auth/totp/setup` caused by invalid color parameters passed to the `segno` QR code library.
- Replace `dark="currentColor"` with `dark="#000000"` and `light="transparent"` with `light=None`, as `segno` does not accept CSS color values.

## Test plan

- [x] 43 TOTP tests pass
- [x] Ruff lint clean
- [x] Basedpyright type check clean
- [x] SVG output validated (black stroke, transparent background, valid XML)
- [ ] Manual verification: boot dev server, navigate onboarding flow, confirm QR code renders and is scannable