### PR TITLE
Fix greenlet_spawn error during post-onboarding library sync

### DIFF
--- a/backend/src/zondarr/api/servers.py
+++ b/backend/src/zondarr/api/servers.py
@@ -558,6 +558,12 @@ class ServerController(Controller):
             api_key=api_key,
         )
 
+        # Refresh the server entity to properly load selectin relationships
+        # within the current greenlet context. Without this, the identity-map
+        # cached entity triggers a greenlet error when sync_libraries_detailed
+        # accesses the lazy-loaded `libraries` relationship.
+        await session.refresh(server)
+
         # Sync libraries after creation (best-effort — don't fail server creation)
         libraries: list[LibraryResponse] = []
         started_at = datetime.now(UTC)


### PR DESCRIPTION
## Summary

Fixes the "greenlet_spawn has not been called; can't call await_only()" error that occurs when libraries are automatically synced after creating a new media server during onboarding.

**Root cause:** After `media_server_service.add()` flushes the new server entity, the subsequent `sync_libraries_detailed()` call retrieves the cached identity-map version via `session.get()`. When SQLAlchemy attempts to execute the `selectin` lazy load for the `libraries` relationship on this cached entity, it fails because the greenlet context is not properly established for the secondary query.

**Fix:** Added `await session.refresh(server)` between server creation and library sync in `ServerController.create_server()`. This forces SQLAlchemy to properly reload the entity and its `selectin` relationships within the current async greenlet context.

## Changes

- `backend/src/zondarr/api/servers.py`: Added `session.refresh(server)` call after `media_server_service.add()` and before `sync_libraries_detailed()`

## Test plan

- [x] All 458 existing tests pass
- [x] Type checking passes (basedpyright, 0 errors)
- [x] Linting passes (ruff, all checks passed)
- [ ] Manual verification: complete onboarding flow with a Plex server and confirm libraries sync automatically without requiring a manual sync