### PR TITLE
Auto-enable secure cookies when CSRF origin is HTTPS

### DIFF
--- a/backend/src/zondarr/api/schemas.py
+++ b/backend/src/zondarr/api/schemas.py
@@ -1127,10 +1127,13 @@ class CsrfOriginResponse(msgspec.Struct, kw_only=True):
         csrf_origin: The configured CSRF origin URL, or null if not set.
         is_locked: True if the value is set via environment variable and cannot
             be changed through the API.
+        secure_cookies_auto_enabled: True when secure cookies were automatically
+            enabled because the CSRF origin was set to an HTTPS URL.
     """
 
     csrf_origin: str | None
     is_locked: bool
+    secure_cookies_auto_enabled: bool = False
 
 
 class CsrfOriginUpdate(msgspec.Struct, kw_only=True, forbid_unknown_fields=True):

--- a/backend/src/zondarr/api/settings.py
+++ b/backend/src/zondarr/api/settings.py
@@ -94,14 +94,18 @@ class SettingsController(Controller):
                 field_errors={"csrf_origin": ["Locked by environment variable"]},
             )
 
-        _ = await settings_service.set_csrf_origin(data.csrf_origin)
+        _, auto_enabled = await settings_service.set_csrf_origin(data.csrf_origin)
         onboarding_service = OnboardingService(
             admin_repo=AdminAccountRepository(session),
             app_setting_repo=app_setting_repository,
         )
         _ = await onboarding_service.complete_security_step()
         origin, locked = await settings_service.get_csrf_origin()
-        return CsrfOriginResponse(csrf_origin=origin, is_locked=locked)
+        return CsrfOriginResponse(
+            csrf_origin=origin,
+            is_locked=locked,
+            secure_cookies_auto_enabled=auto_enabled,
+        )
 
     @get(
         "/secure-cookies",

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -636,6 +636,7 @@ export async function checkOAuthPin(
 export interface CsrfOriginResponse {
 	csrf_origin: string | null;
 	is_locked: boolean;
+	secure_cookies_auto_enabled?: boolean;
 }
 
 /**
@@ -783,9 +784,7 @@ export interface AboutResponse {
  *
  * @param customFetch - Optional fetch function (use SvelteKit's fetch in load functions)
  */
-export async function getAllSettings(
-	customFetch: typeof globalThis.fetch = fetch
-): Promise<{
+export async function getAllSettings(customFetch: typeof globalThis.fetch = fetch): Promise<{
 	data?: AllSettingsResponse;
 	error?: unknown;
 }> {

--- a/frontend/src/lib/components/settings/general-tab.svelte
+++ b/frontend/src/lib/components/settings/general-tab.svelte
@@ -13,7 +13,7 @@ import { Input } from '$lib/components/ui/input';
 import { Label } from '$lib/components/ui/label';
 import { Switch } from '$lib/components/ui/switch';
 import { csrfOriginSchema } from '$lib/schemas/setup';
-import { showApiError, showError, showSuccess } from '$lib/utils/toast';
+import { showApiError, showError, showInfo, showSuccess } from '$lib/utils/toast';
 
 interface Props {
 	csrfOrigin: string | null;
@@ -48,6 +48,10 @@ async function handleSave() {
 			showApiError(result.error);
 		} else {
 			showSuccess('CSRF origin saved');
+			if (result.data?.secure_cookies_auto_enabled) {
+				secureCookiesEnabled = true;
+				showInfo('Secure cookies have been automatically enabled for HTTPS.');
+			}
 		}
 	} finally {
 		saving = false;

--- a/frontend/src/lib/components/setup/step-csrf.svelte
+++ b/frontend/src/lib/components/setup/step-csrf.svelte
@@ -10,6 +10,7 @@ import * as Card from '$lib/components/ui/card';
 import { Input } from '$lib/components/ui/input';
 import { Label } from '$lib/components/ui/label';
 import { csrfOriginSchema } from '$lib/schemas/setup';
+import { showInfo } from '$lib/utils/toast';
 
 interface Props {
 	onComplete: () => void;
@@ -107,6 +108,10 @@ async function handleSubmit() {
 			const errorBody = asErrorResponse(response.error);
 			serverError = errorBody?.detail ?? 'Failed to save CSRF origin';
 			return;
+		}
+
+		if (response.data?.secure_cookies_auto_enabled) {
+			showInfo('Secure cookies have been automatically enabled because your site uses HTTPS.');
 		}
 
 		onComplete();


### PR DESCRIPTION
## Summary

- When a user sets a CSRF origin using HTTPS (during onboarding or in settings), `secure_cookies` is now automatically enabled in the database
- Auto-enablement is skipped when `SECURE_COOKIES` env var is set (locked) or when secure cookies are already enabled
- Frontend shows an informational toast notification when auto-enablement occurs
- Settings page secure cookies toggle updates to reflect the auto-enabled state

## Changes

**Backend:**
- `services/settings.py` — `set_csrf_origin` detects HTTPS origins and auto-enables `secure_cookies`, returns `(AppSetting, auto_enabled)` tuple, logs via structlog
- `api/schemas.py` — `CsrfOriginResponse` extended with `secure_cookies_auto_enabled: bool = False`
- `api/settings.py` — Controller passes the auto-enabled flag through to the response

**Frontend:**
- `lib/api/client.ts` — `CsrfOriginResponse` type updated with `secure_cookies_auto_enabled`
- `lib/components/setup/step-csrf.svelte` — Toast during onboarding when auto-enable happens
- `lib/components/settings/general-tab.svelte` — Toast in settings + toggle state update

**Tests:**
- 8 new tests (6 service + 2 controller) covering HTTPS auto-enable, HTTP/None no-ops, env var lock skip, already-enabled idempotency

## Test plan

- [x] Backend: 466/466 tests pass
- [x] Backend: 0 type errors (basedpyright)
- [x] Backend: 0 lint issues (ruff)
- [x] Frontend: type checking clean (svelte-check)
- [x] Frontend: 301/301 tests pass (3 pre-existing failures unrelated)