### PR TITLE
fix(frontend): resolve Biome 2.4.14 lint and parse errors

### DIFF
--- a/frontend/src/lib/components/pagination.svelte
+++ b/frontend/src/lib/components/pagination.svelte
@@ -72,7 +72,7 @@ function goLast() {
 		{:else}
 			Showing <span class="font-medium text-cr-text">{startItem}</span>
 			to <span class="font-medium text-cr-text">{endItem}</span>
-			of <span class="font-medium text-cr-text">{total}</span> items
+			{'of'} <span class="font-medium text-cr-text">{total}</span> items
 		{/if}
 	</p>
 
@@ -103,7 +103,7 @@ function goLast() {
 		<!-- Page indicator -->
 		<span class="px-3 text-sm font-data text-cr-text-muted">
 			Page <span class="font-medium text-cr-text">{page}</span>
-			of <span class="font-medium text-cr-text">{totalPages}</span>
+			{'of'} <span class="font-medium text-cr-text">{totalPages}</span>
 		</span>
 
 		<Button

--- a/frontend/src/lib/components/settings/totp-disable-dialog.svelte
+++ b/frontend/src/lib/components/settings/totp-disable-dialog.svelte
@@ -66,6 +66,10 @@
 		}
 	}
 
+	function closeDialog() {
+		open = false;
+	}
+
 	$effect(() => {
 		if (open) {
 			resetState();
@@ -129,7 +133,7 @@
 					<Button
 						variant="outline"
 						type="button"
-						onclick={() => (open = false)}
+						onclick={closeDialog}
 						class="border-cr-border bg-cr-surface hover:bg-cr-border text-cr-text"
 					>
 						Cancel

--- a/frontend/src/lib/components/settings/totp-regenerate-dialog.svelte
+++ b/frontend/src/lib/components/settings/totp-regenerate-dialog.svelte
@@ -56,6 +56,10 @@
 		}
 	}
 
+	function closeDialog() {
+		open = false;
+	}
+
 	$effect(() => {
 		if (open) {
 			resetState();
@@ -95,7 +99,7 @@
 			<Dialog.Footer>
 				<Button
 					variant="outline"
-					onclick={() => (open = false)}
+					onclick={closeDialog}
 					disabled={loading}
 					class="border-cr-border bg-cr-surface hover:bg-cr-border text-cr-text"
 				>
@@ -113,7 +117,7 @@
 			<BackupCodesDisplay codes={backupCodes} />
 
 			<Dialog.Footer class="mt-2">
-				<Button onclick={() => (open = false)} class="bg-cr-accent text-cr-bg hover:bg-cr-accent-hover">
+				<Button onclick={closeDialog} class="bg-cr-accent text-cr-bg hover:bg-cr-accent-hover">
 					Done
 				</Button>
 			</Dialog.Footer>

--- a/frontend/src/lib/components/ui/button/index.ts
+++ b/frontend/src/lib/components/ui/button/index.ts
@@ -6,12 +6,12 @@ import Root, {
 } from './button.svelte';
 
 export {
-	Root,
 	type ButtonProps as Props,
-	//
-	Root as Button,
-	buttonVariants,
 	type ButtonProps,
 	type ButtonSize,
-	type ButtonVariant
+	type ButtonVariant,
+	buttonVariants,
+	Root,
+	//
+	Root as Button
 };

--- a/frontend/src/lib/components/ui/card/index.ts
+++ b/frontend/src/lib/components/ui/card/index.ts
@@ -7,19 +7,19 @@ import Header from './card-header.svelte';
 import Title from './card-title.svelte';
 
 export {
-	Root,
-	Content,
-	Description,
-	Footer,
-	Header,
-	Title,
 	Action,
+	Action as CardAction,
+	Content,
+	Content as CardContent,
+	Description,
+	Description as CardDescription,
+	Footer,
+	Footer as CardFooter,
+	Header,
+	Header as CardHeader,
+	Root,
 	//
 	Root as Card,
-	Content as CardContent,
-	Description as CardDescription,
-	Footer as CardFooter,
-	Header as CardHeader,
-	Title as CardTitle,
-	Action as CardAction
+	Title,
+	Title as CardTitle
 };

--- a/frontend/src/lib/components/ui/dialog/index.ts
+++ b/frontend/src/lib/components/ui/dialog/index.ts
@@ -10,25 +10,25 @@ import Title from './dialog-title.svelte';
 import Trigger from './dialog-trigger.svelte';
 
 export {
-	Root,
-	Title,
-	Portal,
-	Footer,
-	Header,
-	Trigger,
-	Overlay,
-	Content,
-	Description,
 	Close,
+	Close as DialogClose,
+	Content,
+	Content as DialogContent,
+	Description,
+	Description as DialogDescription,
+	Footer,
+	Footer as DialogFooter,
+	Header,
+	Header as DialogHeader,
+	Overlay,
+	Overlay as DialogOverlay,
+	Portal,
+	Portal as DialogPortal,
+	Root,
 	//
 	Root as Dialog,
+	Title,
 	Title as DialogTitle,
-	Portal as DialogPortal,
-	Footer as DialogFooter,
-	Header as DialogHeader,
-	Trigger as DialogTrigger,
-	Overlay as DialogOverlay,
-	Content as DialogContent,
-	Description as DialogDescription,
-	Close as DialogClose
+	Trigger,
+	Trigger as DialogTrigger
 };

--- a/frontend/src/lib/components/ui/radio-group/index.ts
+++ b/frontend/src/lib/components/ui/radio-group/index.ts
@@ -2,9 +2,9 @@ import Root from './radio-group.svelte';
 import Item from './radio-group-item.svelte';
 
 export {
-	Root,
 	Item,
+	Item as RadioGroupItem,
+	Root,
 	//
-	Root as RadioGroup,
-	Item as RadioGroupItem
+	Root as RadioGroup
 };

--- a/frontend/src/lib/components/ui/select/index.ts
+++ b/frontend/src/lib/components/ui/select/index.ts
@@ -11,27 +11,27 @@ import Separator from './select-separator.svelte';
 import Trigger from './select-trigger.svelte';
 
 export {
-	Root,
-	Group,
-	Label,
-	Item,
 	Content,
-	Trigger,
-	Separator,
-	ScrollDownButton,
-	ScrollUpButton,
+	Content as SelectContent,
+	Group,
+	Group as SelectGroup,
 	GroupHeading,
+	GroupHeading as SelectGroupHeading,
+	Item,
+	Item as SelectItem,
+	Label,
+	Label as SelectLabel,
 	Portal,
+	Portal as SelectPortal,
+	Root,
 	//
 	Root as Select,
-	Group as SelectGroup,
-	Label as SelectLabel,
-	Item as SelectItem,
-	Content as SelectContent,
-	Trigger as SelectTrigger,
-	Separator as SelectSeparator,
+	ScrollDownButton,
 	ScrollDownButton as SelectScrollDownButton,
+	ScrollUpButton,
 	ScrollUpButton as SelectScrollUpButton,
-	GroupHeading as SelectGroupHeading,
-	Portal as SelectPortal
+	Separator,
+	Separator as SelectSeparator,
+	Trigger,
+	Trigger as SelectTrigger
 };

--- a/frontend/src/lib/components/ui/table/index.ts
+++ b/frontend/src/lib/components/ui/table/index.ts
@@ -8,21 +8,21 @@ import Header from './table-header.svelte';
 import Row from './table-row.svelte';
 
 export {
-	Root,
 	Body,
+	Body as TableBody,
 	Caption,
+	Caption as TableCaption,
 	Cell,
+	Cell as TableCell,
 	Footer,
+	Footer as TableFooter,
 	Head,
+	Head as TableHead,
 	Header,
-	Row,
+	Header as TableHeader,
+	Root,
 	//
 	Root as Table,
-	Body as TableBody,
-	Caption as TableCaption,
-	Cell as TableCell,
-	Footer as TableFooter,
-	Head as TableHead,
-	Header as TableHeader,
+	Row,
 	Row as TableRow
 };

--- a/frontend/src/lib/components/ui/tabs/index.ts
+++ b/frontend/src/lib/components/ui/tabs/index.ts
@@ -4,13 +4,13 @@ import List from './tabs-list.svelte';
 import Trigger from './tabs-trigger.svelte';
 
 export {
-	Root,
 	Content,
+	Content as TabsContent,
 	List,
-	Trigger,
+	List as TabsList,
+	Root,
 	//
 	Root as Tabs,
-	Content as TabsContent,
-	List as TabsList,
+	Trigger,
 	Trigger as TabsTrigger
 };

--- a/frontend/src/lib/components/wizard/wizard-progress.svelte
+++ b/frontend/src/lib/components/wizard/wizard-progress.svelte
@@ -37,7 +37,7 @@ const isComplete = $derived(current === total && progress >= 100);
 	</div>
 
 	<!-- Accessible step label -->
-	<span class="step-label" aria-live="polite">Step {current} of {total}</span>
+	<span class="step-label" aria-live="polite">Step {current} {'of'} {total}</span>
 </div>
 
 <style>

--- a/frontend/src/lib/components/wizard/wizard-shell.svelte
+++ b/frontend/src/lib/components/wizard/wizard-shell.svelte
@@ -442,15 +442,15 @@ async function handleInteractionValidate(
 					{/if}
 
 					{#each currentInteractions as interaction, idx (interaction.id)}
-						{@const registration = getInteractionType(interaction.interaction_type)}
+						{@const interactionDef = getInteractionType(interaction.interaction_type)}
 						{@const isCompleted = currentCompletions.has(interaction.id)}
 
 						{#if isMultiInteraction && idx > 0}
 							<div class="interaction-divider"></div>
 						{/if}
 
-						{#if registration}
-							{@const InteractionComponent = registration.interactionComponent}
+						{#if interactionDef}
+							{@const InteractionComponent = interactionDef.interactionComponent}
 							<div
 								class="interaction-block"
 								class:completed={isCompleted && isMultiInteraction}
@@ -465,7 +465,7 @@ async function handleInteractionValidate(
 												</svg>
 											{/if}
 										</div>
-										<span class="interaction-label">{registration.label}</span>
+										<span class="interaction-label">{interactionDef.label}</span>
 									</div>
 								{/if}
 

--- a/frontend/src/routes/(admin)/+layout.svelte
+++ b/frontend/src/routes/(admin)/+layout.svelte
@@ -43,6 +43,20 @@ async function handleLogout() {
 // Mobile menu state
 let mobileMenuOpen = $state(false);
 
+function toggleMobileMenu() {
+	mobileMenuOpen = !mobileMenuOpen;
+}
+
+function closeMobileMenu() {
+	mobileMenuOpen = false;
+}
+
+function handleOverlayKeydown(event: KeyboardEvent) {
+	if (event.key === "Escape") {
+		closeMobileMenu();
+	}
+}
+
 // Derive current section title from route
 const currentTitle = $derived.by(() => {
 	const pathname = page.url.pathname;
@@ -80,7 +94,7 @@ $effect(() => {
 		<Button
 			variant="ghost"
 			size="icon"
-			onclick={() => (mobileMenuOpen = !mobileMenuOpen)}
+			onclick={toggleMobileMenu}
 			aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
 			aria-expanded={mobileMenuOpen}
 			class="text-cr-text-muted hover:text-cr-accent"
@@ -99,8 +113,8 @@ $effect(() => {
 	{#if mobileMenuOpen}
 		<div
 			class="fixed inset-0 z-40 bg-black/50 md:hidden"
-			onclick={() => (mobileMenuOpen = false)}
-			onkeydown={(e) => e.key === 'Escape' && (mobileMenuOpen = false)}
+			onclick={closeMobileMenu}
+			onkeydown={handleOverlayKeydown}
 			role="button"
 			tabindex="-1"
 			aria-label="Close menu"


### PR DESCRIPTION
## Summary

The `Pre-commit Checks` job in the Code Quality workflow has been failing on `main` since commit `0d25934`. This PR resolves all blocking diagnostics so `prek run --all-files --hook-stage manual` (the exact invocation used by CI) passes again.

## Root cause

Biome `2.4.14` was added to `frontend/package.json` in `42ef48b`, but `frontend/bun.lock` continued to resolve `@biomejs/biome@2.4.4` until commit `b98eb5d` regenerated it via `bun update`. The first push that actually executed Biome `2.4.14` in CI (`0d25934`) surfaced three new classes of diagnostic that the prior installation never raised:

1. Auto-applied alphabetical re-sorting of named exports across the shadcn-svelte index barrels.
2. `lint/suspicious/noGlobalAssign` and `lint/suspicious/noAssignInExpressions` errors triggered when Svelte 5 `$bindable` props happen to share a name with a DOM/Worker global (`open`, `registration`).
3. A regression in Biome's experimental Svelte parser where the bare token `of` directly following a closing `}` is misclassified as the JS `for…of` keyword, producing a parse error.

Because the prek hook entry is `biome check --write`, Biome rewrote files in CI and exited non-zero, which prek surfaces as a failure.

## Changes

### Import re-ordering accepted (auto-fix)

Biome's organize-imports now alphabetizes the export blocks in the following barrel files. The output is committed verbatim:

- `frontend/src/lib/components/ui/button/index.ts`
- `frontend/src/lib/components/ui/card/index.ts`
- `frontend/src/lib/components/ui/dialog/index.ts`
- `frontend/src/lib/components/ui/radio-group/index.ts`
- `frontend/src/lib/components/ui/select/index.ts`
- `frontend/src/lib/components/ui/table/index.ts`
- `frontend/src/lib/components/ui/tabs/index.ts`

### Parse errors fixed

Biome `2.4.14` rejects the pattern `}<whitespace>of<whitespace>{` inside Svelte template text — a regression isolated to the lowercase `of` token (`OF`, `from`, comma-separated forms all parse). The minimal workaround is to wrap the literal as a JS expression `{'of'}`, which preserves rendered output unchanged:

- `frontend/src/lib/components/pagination.svelte` — both pagination summaries (`Showing X to Y {'of'} Z items` and `Page X {'of'} Y`).
- `frontend/src/lib/components/wizard/wizard-progress.svelte` — `aria-live` step label (`Step X {'of'} Y`).

### `noGlobalAssign` / `noAssignInExpressions` fixed

`open` and `registration` are recognised by Biome as DOM globals (`window.open`, `ServiceWorkerRegistration`). When a Svelte 5 `$bindable()` prop or `{@const}` binding shares the name, inline assignments such as `() => (open = false)` now error. The fix extracts each assignment into a named function (so the assignment lives in a normal declaration scope) or renames the local:

- `frontend/src/lib/components/settings/totp-disable-dialog.svelte` — added `closeDialog()` helper; replaced the inline cancel handler.
- `frontend/src/lib/components/settings/totp-regenerate-dialog.svelte` — same `closeDialog()` helper; replaced both Cancel and Done handlers.
- `frontend/src/lib/components/wizard/wizard-shell.svelte` — renamed the `{@const registration}` inside the `{#each}` block to `interactionDef` (and updated the three downstream references).
- `frontend/src/routes/(admin)/+layout.svelte` — extracted `toggleMobileMenu`, `closeMobileMenu`, and `handleOverlayKeydown` helpers; replaced the inline mobile-menu handlers including the `onkeydown` expression that triggered `noAssignInExpressions`.

No public component API or rendered behaviour changes.

## Verification

Locally, on this branch:

- `SKIP=no-commit-to-branch prek run --all-files --hook-stage manual` — all 11 hooks pass (trim trailing whitespace, fix end of files, check yaml/json/toml, check for merge conflicts, detect private key, check for added large files, ruff check, ruff format, Format and lint with Biome).
- `bunx biome check .` (from `frontend/`) — exits 0; remaining output is 10 warnings and 3 infos, none of which are errors.
- `cd backend && uv run basedpyright` — `0 errors, 0 warnings, 0 notes`.
- `cd backend && uv run pytest` — `756 passed`.
- `bun --cwd frontend run test` — `302 passed (31 files)`.

## Out of scope

While investigating I noticed the `Type Checking` job's `bun --cwd frontend run check` step prints `bun run` usage instead of executing the script (visible in every recent CI log), which means `svelte-check` has not actually been running in CI. There are two pre-existing `client.ts` type errors (the `openapi-typescript` schema emits `OAuthPinResponse | unknown` for two `/oauth/pin` responses) that this masks. Both issues are unrelated to the prek failure and are left for a separate change.

## Test plan

- [ ] CI `Pre-commit Checks` job passes on this branch.
- [ ] CI `Tests` job passes.
- [ ] Manual smoke test of the affected components in dev:
  - [ ] TOTP disable dialog Cancel button still closes the dialog.
  - [ ] TOTP regenerate dialog Cancel and Done buttons still close the dialog.
  - [ ] Admin mobile sidebar toggle button opens/closes; overlay click and Escape key both close the menu.
  - [ ] Pagination summary text and page indicator render unchanged ("Showing 1 to 10 of 42 items", "Page 1 of 5").
  - [ ] Wizard progress shows the accessible "Step X of Y" label unchanged.
  - [ ] Wizard renders interaction blocks correctly (verifies `interactionDef` rename did not break the `{#each}`).