### PR TITLE
fix(ci): restore svelte-check and clean up OpenAPI schemas

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -92,7 +92,7 @@ jobs:
         run: cd backend && uv run basedpyright
 
       - name: Run svelte-check
-        run: bun --cwd frontend run check
+        run: bun run --cwd frontend check
 
   test:
     name: Tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       # TypeScript type checking (pre-push only)
       - id: typecheck-ts
         name: TypeScript Check
-        entry: bun --cwd frontend run check
+        entry: bun run --cwd frontend check
         language: system
         pass_filenames: false
         files: ^frontend/.*\.(ts|svelte)$
@@ -68,7 +68,7 @@ repos:
       # Frontend tests (pre-push only)
       - id: tests-ts
         name: Frontend Tests
-        entry: bun --cwd frontend test
+        entry: bun run --cwd frontend test
         language: system
         files: ^frontend/.*\.(ts|svelte)$
         pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ bun run dev                        # Dev server
 bun run build                      # Production build (svelte-adapter-bun)
 bun run test                       # Run tests (vitest)
 bun run test -- src/path/file.test.ts  # Run single test file
-bun --cwd frontend run check       # svelte-check type checking
+bun run --cwd frontend check       # svelte-check type checking
 ```
 
 ### Root-level

--- a/backend/src/zondarr/api/errors.py
+++ b/backend/src/zondarr/api/errors.py
@@ -27,11 +27,13 @@ from litestar.status_codes import (
     HTTP_404_NOT_FOUND,
     HTTP_500_INTERNAL_SERVER_ERROR,
     HTTP_502_BAD_GATEWAY,
+    HTTP_503_SERVICE_UNAVAILABLE,
 )
 
 from ..core.exceptions import (
     AuthenticationError,
     ExternalServiceError,
+    MediaServerUnreachableError,
     NotFoundError,
     RedemptionError,
     ValidationError,
@@ -316,4 +318,40 @@ def external_service_error_handler(
             correlation_id=correlation_id,
         ),
         status_code=HTTP_502_BAD_GATEWAY,
+    )
+
+
+def media_server_unreachable_error_handler(
+    request: Request[object, object, State],
+    exc: MediaServerUnreachableError,
+) -> Response[ErrorResponse]:
+    """Handle MediaServerUnreachableError exceptions.
+
+    Returns HTTP 503 with server identification.
+    Logs the unreachable event with correlation ID for debugging.
+
+    Args:
+        request: The incoming request.
+        exc: The MediaServerUnreachableError exception.
+
+    Returns:
+        Response with ErrorResponse body and HTTP 503 status.
+    """
+    correlation_id = _generate_correlation_id()
+
+    logger.warning(
+        "Media server unreachable",
+        correlation_id=correlation_id,
+        server_id=exc.server_id,
+        path=str(request.url.path),
+    )
+
+    return Response(
+        ErrorResponse(
+            detail=f"Media server unreachable: {exc.message}",
+            error_code=exc.error_code,
+            timestamp=datetime.now(UTC),
+            correlation_id=correlation_id,
+        ),
+        status_code=HTTP_503_SERVICE_UNAVAILABLE,
     )

--- a/backend/src/zondarr/api/oauth.py
+++ b/backend/src/zondarr/api/oauth.py
@@ -261,6 +261,10 @@ class OAuthController(Controller):
         ),
         exclude_from_auth=True,
         responses={
+            200: ResponseSpec(
+                data_container=OAuthCheckResponse,
+                description="OAuth PIN completion result.",
+            ),
             400: ResponseSpec(
                 data_container=ErrorResponse,
                 description="Test credentials missing or session already redeemed.",
@@ -273,7 +277,7 @@ class OAuthController(Controller):
         state: State,
         provider: Annotated[str, Parameter(description="Provider name")],
         handle: Annotated[str, Parameter(description="Opaque PIN handle")],
-    ) -> Response[OAuthCheckResponse] | Response[ErrorResponse]:
+    ) -> OAuthCheckResponse | Response[ErrorResponse]:
         """Simulate OAuth PIN completion for E2E testing.
 
         Only available when debug mode is enabled and test credentials
@@ -318,13 +322,10 @@ class OAuthController(Controller):
                 oauth_session.redemption_token is not None
                 and not oauth_session.redeemed
             ):
-                return Response(
-                    OAuthCheckResponse(
-                        authenticated=True,
-                        redemption_token=oauth_session.redemption_token,
-                        email=oauth_session.email,
-                    ),
-                    status_code=HTTP_200_OK,
+                return OAuthCheckResponse(
+                    authenticated=True,
+                    redemption_token=oauth_session.redemption_token,
+                    email=oauth_session.email,
                 )
 
             # If already redeemed, the session has been consumed
@@ -359,11 +360,8 @@ class OAuthController(Controller):
             has_email=True,
         )
 
-        return Response(
-            OAuthCheckResponse(
-                authenticated=True,
-                redemption_token=redemption_token,
-                email=settings.plex_test_email,
-            ),
-            status_code=HTTP_200_OK,
+        return OAuthCheckResponse(
+            authenticated=True,
+            redemption_token=redemption_token,
+            email=settings.plex_test_email,
         )

--- a/backend/src/zondarr/api/oauth.py
+++ b/backend/src/zondarr/api/oauth.py
@@ -20,17 +20,17 @@ from typing import TYPE_CHECKING, Annotated, cast
 import structlog
 from litestar import Controller, Response, get, post
 from litestar.datastructures import State
+from litestar.openapi.datastructures import ResponseSpec
 from litestar.params import Parameter
 from litestar.status_codes import (
     HTTP_200_OK,
     HTTP_400_BAD_REQUEST,
-    HTTP_502_BAD_GATEWAY,
 )
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from zondarr.api.schemas import ErrorResponse, OAuthCheckResponse, OAuthPinResponse
 from zondarr.config import Settings
-from zondarr.core.exceptions import NotFoundError
+from zondarr.core.exceptions import ExternalServiceError, NotFoundError
 from zondarr.media.exceptions import UnknownServerTypeError
 from zondarr.media.providers.plex.oauth_service import PlexOAuthError
 from zondarr.media.registry import registry
@@ -89,13 +89,19 @@ class OAuthController(Controller):
             "Returns an opaque handle for polling the PIN status."
         ),
         exclude_from_auth=True,
+        responses={
+            502: ResponseSpec(
+                data_container=ErrorResponse,
+                description="External provider unavailable.",
+            ),
+        },
     )
     async def create_pin(
         self,
         settings: Settings,
         state: State,
         provider: Annotated[str, Parameter(description="Provider name")],
-    ) -> OAuthPinResponse | Response[ErrorResponse]:
+    ) -> OAuthPinResponse:
         """Generate OAuth PIN and return auth URL with opaque handle.
 
         Args:
@@ -117,14 +123,7 @@ class OAuthController(Controller):
                 operation=exc.operation,
                 error=exc.message,
             )
-            return Response(
-                ErrorResponse(
-                    detail=f"External service unavailable: {provider}",
-                    error_code="EXTERNAL_SERVICE_ERROR",
-                    timestamp=datetime.now(UTC),
-                ),
-                status_code=HTTP_502_BAD_GATEWAY,
-            )
+            raise ExternalServiceError(provider, exc.message, original=exc) from exc
         finally:
             await flow.close()
 
@@ -155,6 +154,12 @@ class OAuthController(Controller):
             "if authentication is complete."
         ),
         exclude_from_auth=True,
+        responses={
+            502: ResponseSpec(
+                data_container=ErrorResponse,
+                description="External provider unavailable.",
+            ),
+        },
     )
     async def check_pin(
         self,
@@ -162,7 +167,7 @@ class OAuthController(Controller):
         state: State,
         provider: Annotated[str, Parameter(description="Provider name")],
         handle: Annotated[str, Parameter(description="Opaque PIN handle")],
-    ) -> OAuthCheckResponse | Response[ErrorResponse]:
+    ) -> OAuthCheckResponse:
         """Check if PIN has been authenticated.
 
         Uses short-lived database sessions to avoid holding SQLite's write lock
@@ -218,14 +223,7 @@ class OAuthController(Controller):
                 operation=exc.operation,
                 error=exc.message,
             )
-            return Response(
-                ErrorResponse(
-                    detail=f"External service unavailable: {provider}",
-                    error_code="EXTERNAL_SERVICE_ERROR",
-                    timestamp=datetime.now(UTC),
-                ),
-                status_code=HTTP_502_BAD_GATEWAY,
-            )
+            raise ExternalServiceError(provider, exc.message, original=exc) from exc
         finally:
             await flow.close()
 
@@ -262,6 +260,12 @@ class OAuthController(Controller):
             "debug mode is disabled."
         ),
         exclude_from_auth=True,
+        responses={
+            400: ResponseSpec(
+                data_container=ErrorResponse,
+                description="Test credentials missing or session already redeemed.",
+            ),
+        },
     )
     async def test_complete_pin(
         self,
@@ -269,7 +273,7 @@ class OAuthController(Controller):
         state: State,
         provider: Annotated[str, Parameter(description="Provider name")],
         handle: Annotated[str, Parameter(description="Opaque PIN handle")],
-    ) -> OAuthCheckResponse | Response[ErrorResponse]:
+    ) -> Response[OAuthCheckResponse] | Response[ErrorResponse]:
         """Simulate OAuth PIN completion for E2E testing.
 
         Only available when debug mode is enabled and test credentials
@@ -314,10 +318,13 @@ class OAuthController(Controller):
                 oauth_session.redemption_token is not None
                 and not oauth_session.redeemed
             ):
-                return OAuthCheckResponse(
-                    authenticated=True,
-                    redemption_token=oauth_session.redemption_token,
-                    email=oauth_session.email,
+                return Response(
+                    OAuthCheckResponse(
+                        authenticated=True,
+                        redemption_token=oauth_session.redemption_token,
+                        email=oauth_session.email,
+                    ),
+                    status_code=HTTP_200_OK,
                 )
 
             # If already redeemed, the session has been consumed
@@ -352,8 +359,11 @@ class OAuthController(Controller):
             has_email=True,
         )
 
-        return OAuthCheckResponse(
-            authenticated=True,
-            redemption_token=redemption_token,
-            email=settings.plex_test_email,
+        return Response(
+            OAuthCheckResponse(
+                authenticated=True,
+                redemption_token=redemption_token,
+                email=settings.plex_test_email,
+            ),
+            status_code=HTTP_200_OK,
         )

--- a/backend/src/zondarr/api/servers.py
+++ b/backend/src/zondarr/api/servers.py
@@ -13,19 +13,24 @@ Uses Litestar Controller pattern with dependency injection for services.
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, cast
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import structlog
 from litestar import Controller, Request, Response, delete, get, post
 from litestar.datastructures import State
 from litestar.di import Provide
+from litestar.openapi.datastructures import ResponseSpec
 from litestar.params import Parameter
-from litestar.status_codes import HTTP_503_SERVICE_UNAVAILABLE
+from litestar.status_codes import HTTP_200_OK
 from litestar.types import AnyCallable
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from zondarr.config import Settings
-from zondarr.core.exceptions import NotFoundError, ValidationError
+from zondarr.core.exceptions import (
+    MediaServerUnreachableError,
+    NotFoundError,
+    ValidationError,
+)
 from zondarr.core.tasks import BackgroundTaskManager
 from zondarr.media.exceptions import MediaClientError
 from zondarr.media.registry import registry
@@ -872,8 +877,15 @@ class ServerController(Controller):
 
     @post(
         "/{server_id:uuid}/sync",
+        status_code=HTTP_200_OK,
         summary="Sync users with media server",
         description="Synchronize local user records with the actual state of users on the media server.",
+        responses={
+            503: ResponseSpec(
+                data_container=ErrorResponse,
+                description="Media server unreachable.",
+            ),
+        },
     )
     async def sync_server(
         self,
@@ -884,7 +896,7 @@ class ServerController(Controller):
         data: SyncRequest,
         sync_service: SyncService,
         sync_run_repository: SyncRunRepository,
-    ) -> Response[SyncResult] | Response[ErrorResponse]:
+    ) -> Response[SyncResult]:
         """Sync users between local database and media server.
 
         Fetches all users from the media server and compares them with
@@ -901,10 +913,11 @@ class ServerController(Controller):
 
         Returns:
             SyncResult with discrepancy report on success.
-            ErrorResponse with HTTP 503 if server is unreachable.
 
         Raises:
             NotFoundError: If the server does not exist.
+            MediaServerUnreachableError: If the media server cannot be reached
+                (mapped to HTTP 503 by the registered error handler).
         """
         started_at = datetime.now(UTC)
         try:
@@ -933,26 +946,9 @@ class ServerController(Controller):
                     started_at=started_at,
                     error_message=e.message,
                 )
-            # Return 503 if server is unreachable
-            correlation_id = str(uuid4())
-
-            logger.warning(
-                "Media server unreachable during sync",
-                correlation_id=correlation_id,
-                server_id=str(server_id),
-                operation=e.operation,
-                cause=e.cause,
-            )
-
-            return Response(
-                ErrorResponse(
-                    detail=f"Media server unreachable: {e.message}",
-                    error_code="SERVER_UNREACHABLE",
-                    timestamp=datetime.now(UTC),
-                    correlation_id=correlation_id,
-                ),
-                status_code=HTTP_503_SERVICE_UNAVAILABLE,
-            )
+            raise MediaServerUnreachableError(
+                str(server_id), e.message, original=e
+            ) from e
         except Exception as exc:
             if not data.dry_run:
                 await self._record_sync_run(

--- a/backend/src/zondarr/app.py
+++ b/backend/src/zondarr/app.py
@@ -48,6 +48,7 @@ from zondarr.api.errors import (
     external_service_error_handler,
     internal_error_handler,
     litestar_http_exception_handler,
+    media_server_unreachable_error_handler,
     not_found_handler,
     redemption_error_handler,
     validation_error_handler,
@@ -70,6 +71,7 @@ from zondarr.core.database import db_lifespan, provide_db_session
 from zondarr.core.exceptions import (
     AuthenticationError,
     ExternalServiceError,
+    MediaServerUnreachableError,
     NotFoundError,
     RedemptionError,
     ValidationError,
@@ -407,6 +409,7 @@ def create_app(settings: Settings | None = None) -> Litestar:
             ValidationError: validation_error_handler,
             NotFoundError: not_found_handler,
             ExternalServiceError: external_service_error_handler,
+            MediaServerUnreachableError: media_server_unreachable_error_handler,
             LitestarHTTPException: litestar_http_exception_handler,
             Exception: internal_error_handler,
         },

--- a/backend/src/zondarr/core/exceptions.py
+++ b/backend/src/zondarr/core/exceptions.py
@@ -184,3 +184,33 @@ class ExternalServiceError(ZondarrError):
         )
         self.service_name = service_name
         self.original = original
+
+
+class MediaServerUnreachableError(ZondarrError):
+    """Raised when a media server cannot be reached during sync.
+
+    Mapped to HTTP 503 by ``media_server_unreachable_error_handler``.
+
+    Attributes:
+        server_id: The UUID of the media server that was unreachable.
+        original: The underlying ``MediaClientError`` that triggered this, if any.
+    """
+
+    server_id: str
+    original: Exception | None
+
+    def __init__(
+        self,
+        server_id: str,
+        message: str,
+        /,
+        *,
+        original: Exception | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            "SERVER_UNREACHABLE",
+            server_id=server_id,
+        )
+        self.server_id = server_id
+        self.original = original

--- a/backend/tests/test_oauth_controller_errors.py
+++ b/backend/tests/test_oauth_controller_errors.py
@@ -15,8 +15,13 @@ from litestar.testing import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from tests.conftest import create_test_engine
+from zondarr.api.errors import (
+    external_service_error_handler,
+    not_found_handler,
+)
 from zondarr.api.oauth import OAuthController
 from zondarr.config import Settings
+from zondarr.core.exceptions import ExternalServiceError, NotFoundError
 from zondarr.media.providers.plex.oauth_service import PlexOAuthError
 
 
@@ -45,6 +50,10 @@ def _make_test_app(
             "settings": Provide(lambda: settings, sync_to_thread=False),
         },
         state=State({"session_factory": session_factory}),
+        exception_handlers={
+            ExternalServiceError: external_service_error_handler,
+            NotFoundError: not_found_handler,
+        },
     )
     return app
 

--- a/backend/tests/test_server_sync_status.py
+++ b/backend/tests/test_server_sync_status.py
@@ -318,7 +318,7 @@ class TestServerSyncStatus:
                         f"/api/v1/servers/{server_id}/sync",
                         json={"dry_run": False},
                     )
-                    assert response.status_code == 201
+                    assert response.status_code == 200
 
             async with session_factory() as session:
                 runs = (

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -131,18 +131,7 @@ export type MediaServerWithLibrariesResponse =
 export type LibraryResponse = components['schemas']['LibraryResponse'];
 
 export type SyncRequest = components['schemas']['SyncRequest'];
-
-// SyncResult is manually defined because the OpenAPI generator doesn't handle
-// Union return types well (Response[SyncResult] | Response[ErrorResponse])
-export interface SyncResult {
-	server_id: string;
-	server_name: string;
-	synced_at: string;
-	orphaned_users: string[];
-	stale_users: string[];
-	matched_users: number;
-	imported_users: number;
-}
+export type SyncResult = components['schemas']['SyncResult'];
 
 export interface SyncChannelStatus {
 	in_progress: boolean;

--- a/frontend/src/lib/api/types.d.ts
+++ b/frontend/src/lib/api/types.d.ts
@@ -1303,7 +1303,7 @@ export interface components {
 		 * @example {
 		 *       "detail": "dueXWxItGmpndvrqpUKE",
 		 *       "error_code": "voiQUvZgiPQBXBLnzSvg",
-		 *       "timestamp": "2008-07-18T15:34:50.008312",
+		 *       "timestamp": "2008-07-18T16:12:37.008312",
 		 *       "correlation_id": null
 		 *     }
 		 */
@@ -1314,7 +1314,7 @@ export interface components {
 			error_code: string;
 			/**
 			 * Format: date-time
-			 * @example 2006-05-16T19:37:24.423369
+			 * @example 2006-05-16T20:15:11.423369
 			 */
 			timestamp: string;
 			/** @example gGCCJMLRlAzRIOjdLiFB */
@@ -1591,9 +1591,9 @@ export interface components {
 		 *           "external_user_id": "babcOYguawIGUCctxrbG",
 		 *           "username": "zKsdnjxheBhfgKPQDHNw",
 		 *           "enabled": false,
-		 *           "created_at": "2000-09-18T10:23:39.770009",
-		 *           "expires_at": "1998-02-12T14:52:48.488298",
-		 *           "updated_at": "1998-01-13T16:07:00.279514"
+		 *           "created_at": "2000-09-18T11:01:26.770009",
+		 *           "expires_at": "1998-02-12T15:30:35.488298",
+		 *           "updated_at": "1998-01-13T16:44:47.279514"
 		 *         }
 		 *       ]
 		 *     }
@@ -1621,9 +1621,9 @@ export interface components {
 			 *         "external_user_id": "PriLBPewTdWxyxwFswQX",
 			 *         "username": "AufHcSHjwVUDXFiXlEfD",
 			 *         "enabled": true,
-			 *         "created_at": "2005-06-01T10:01:29.848019",
+			 *         "created_at": "2005-06-01T10:39:16.848019",
 			 *         "external_user_type": "SuNeNziQYWrbRjKhHKYu",
-			 *         "updated_at": "2020-09-24T09:56:34.527288"
+			 *         "updated_at": "2020-09-24T10:34:21.527288"
 			 *       }
 			 *     ]
 			 */
@@ -2779,13 +2779,13 @@ export interface operations {
 		};
 		requestBody?: never;
 		responses: {
-			/** @description Request fulfilled, document follows */
+			/** @description OAuth PIN completion result. */
 			200: {
 				headers: {
 					[name: string]: unknown;
 				};
 				content: {
-					'application/json': unknown;
+					'application/json': components['schemas']['OAuthCheckResponse'];
 				};
 			};
 			/** @description Test credentials missing or session already redeemed. */

--- a/frontend/src/lib/api/types.d.ts
+++ b/frontend/src/lib/api/types.d.ts
@@ -267,6 +267,26 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/api/v1/join/health/{code}': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Check target server health
+		 * @description Check reachability of target media servers for an invitation code.
+		 */
+		get: operations['ApiV1JoinHealthCodeCheckHealth'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	'/api/v1/join/{code}': {
 		parameters: {
 			query?: never;
@@ -1278,6 +1298,28 @@ export interface components {
 		EnvCredentialsResponse: {
 			credentials: components['schemas']['EnvCredentialResponse'][];
 		};
+		/**
+		 * ErrorResponse
+		 * @example {
+		 *       "detail": "dueXWxItGmpndvrqpUKE",
+		 *       "error_code": "voiQUvZgiPQBXBLnzSvg",
+		 *       "timestamp": "2008-07-18T15:34:50.008312",
+		 *       "correlation_id": null
+		 *     }
+		 */
+		ErrorResponse: {
+			/** @example dkahSRhbAKyyyVhuiIKQ */
+			detail: string;
+			/** @example jAycEiKZzsXNStUXMqcc */
+			error_code: string;
+			/**
+			 * Format: date-time
+			 * @example 2006-05-16T19:37:24.423369
+			 */
+			timestamp: string;
+			/** @example gGCCJMLRlAzRIOjdLiFB */
+			correlation_id?: string | null;
+		};
 		/** ExpirationIntervalUpdate */
 		ExpirationIntervalUpdate: {
 			expiration_check_interval_seconds: number;
@@ -1536,22 +1578,22 @@ export interface components {
 		/**
 		 * RedemptionErrorResponse
 		 * @example {
-		 *       "success": false,
-		 *       "error_code": "AsuEshTKFLZjQQrDxkwh",
-		 *       "message": "WjGDYPstccqXcjHsjXcF",
+		 *       "success": true,
+		 *       "error_code": "fLqpHUrVGFBaiJKfHyEu",
+		 *       "message": "lsYjSBdQaRrVLsGZikpQ",
 		 *       "correlation_id": null,
 		 *       "failed_server": null,
 		 *       "partial_users": [
 		 *         {
-		 *           "id": "c2713ce2-5868-405b-93e6-d9036dc3ccee",
-		 *           "identity_id": "2b1acaa9-29ad-405f-bddd-cc7231e6ff39",
-		 *           "media_server_id": "f69b0ae6-c099-4c4c-8f10-8ed367d731e1",
-		 *           "external_user_id": "yOTjTEvAUueXgfLqpHUr",
-		 *           "username": "VGFBaiJKfHyEulsYjSBd",
-		 *           "enabled": true,
-		 *           "created_at": "1996-09-28T19:46:53.921080",
-		 *           "expires_at": "2021-05-04T20:58:44.723815",
-		 *           "updated_at": "2006-05-19T09:24:12.944409"
+		 *           "id": "62e6750a-3f13-491d-a7fc-c18b3f36d149",
+		 *           "identity_id": "9875bad1-95a6-4ea9-8b87-3e099d5d310b",
+		 *           "media_server_id": "c2cc1d38-8d15-4800-9fad-ea816b327c79",
+		 *           "external_user_id": "babcOYguawIGUCctxrbG",
+		 *           "username": "zKsdnjxheBhfgKPQDHNw",
+		 *           "enabled": false,
+		 *           "created_at": "2000-09-18T10:23:39.770009",
+		 *           "expires_at": "1998-02-12T14:52:48.488298",
+		 *           "updated_at": "1998-01-13T16:07:00.279514"
 		 *         }
 		 *       ]
 		 *     }
@@ -1562,26 +1604,26 @@ export interface components {
 			 * @example false
 			 */
 			success: boolean;
-			/** @example bzayzoQbzdXMsvhsvQnj */
-			error_code: string;
-			/** @example psxSmwtEmkVBOmIxyHqA */
-			message: string;
 			/** @example xJhBSnpIXjjOrlCcUmnv */
+			error_code: string;
+			/** @example iVzUMZozziJUhCsuKDfY */
+			message: string;
+			/** @example MqbkVDGbgpSmpeFCZfQi */
 			correlation_id?: string | null;
-			/** @example RTwdshFRPhSOVrnPxrBB */
+			/** @example gOawvtQkOPQsswkMypzV */
 			failed_server?: string | null;
 			/**
 			 * @example [
 			 *       {
-			 *         "id": "4133e4d7-5916-4281-8e24-d9ccd2ea3f17",
-			 *         "identity_id": "c2680192-6c96-4b0e-b4f5-add55c37849a",
-			 *         "media_server_id": "4850e927-bfdb-43be-a0fb-c247319115d0",
-			 *         "external_user_id": "ypzVvHsoVSEeCtLViFvD",
-			 *         "username": "EMpEHdutFmqCQcDdvDZV",
-			 *         "enabled": false,
-			 *         "created_at": "1996-09-15T05:55:54.852486",
-			 *         "external_user_type": "kSDBQNXqcJcDSuFiiFSZ",
-			 *         "updated_at": "1997-02-27T14:21:13.373028"
+			 *         "id": "65a3a495-ef67-4106-9c17-ae6e5daffa15",
+			 *         "identity_id": "2be2d8c9-a36b-4de4-99e5-8ba2531670d8",
+			 *         "media_server_id": "9b266ccc-1e0e-47c5-a861-5e14c5d09b94",
+			 *         "external_user_id": "PriLBPewTdWxyxwFswQX",
+			 *         "username": "AufHcSHjwVUDXFiXlEfD",
+			 *         "enabled": true,
+			 *         "created_at": "2005-06-01T10:01:29.848019",
+			 *         "external_user_type": "SuNeNziQYWrbRjKhHKYu",
+			 *         "updated_at": "2020-09-24T09:56:34.527288"
 			 *       }
 			 *     ]
 			 */
@@ -1683,6 +1725,19 @@ export interface components {
 		SyncRequest: {
 			/** @default true */
 			dry_run: boolean;
+		};
+		/** SyncResult */
+		SyncResult: {
+			/** Format: uuid */
+			server_id: string;
+			server_name: string;
+			/** Format: date-time */
+			synced_at: string;
+			orphaned_users: string[];
+			stale_users: string[];
+			matched_users: number;
+			/** @default 0 */
+			imported_users: number;
 		};
 		/** TOTPBackupCodeRequest */
 		TOTPBackupCodeRequest: {
@@ -2520,6 +2575,58 @@ export interface operations {
 			};
 		};
 	};
+	ApiV1JoinHealthCodeCheckHealth: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				/** @description Invitation code to check health for */
+				code: string;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Request fulfilled, document follows */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': unknown;
+				};
+			};
+			/** @description Bad request syntax or unsupported method */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						status_code: number;
+						detail: string;
+						extra?:
+							| null
+							| {
+									[key: string]: unknown;
+							  }
+							| unknown[];
+					};
+				};
+			};
+			/** @description Invalid or expired invitation code. */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						[key: string]: string;
+					};
+				};
+			};
+		};
+	};
 	ApiV1JoinCodeRedeemInvitation: {
 		parameters: {
 			query?: never;
@@ -2576,7 +2683,7 @@ export interface operations {
 					[name: string]: unknown;
 				};
 				content: {
-					'application/json': components['schemas']['OAuthCheckResponse'] | unknown;
+					'application/json': components['schemas']['OAuthCheckResponse'];
 				};
 			};
 			/** @description Bad request syntax or unsupported method */
@@ -2595,6 +2702,15 @@ export interface operations {
 							  }
 							| unknown[];
 					};
+				};
+			};
+			/** @description External provider unavailable. */
+			502: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
 				};
 			};
 		};
@@ -2617,7 +2733,7 @@ export interface operations {
 					[name: string]: unknown;
 				};
 				content: {
-					'application/json': components['schemas']['OAuthPinResponse'] | unknown;
+					'application/json': components['schemas']['OAuthPinResponse'];
 				};
 			};
 			/** @description Bad request syntax or unsupported method */
@@ -2636,6 +2752,15 @@ export interface operations {
 							  }
 							| unknown[];
 					};
+				};
+			};
+			/** @description External provider unavailable. */
+			502: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
 				};
 			};
 		};
@@ -2660,25 +2785,16 @@ export interface operations {
 					[name: string]: unknown;
 				};
 				content: {
-					'application/json': components['schemas']['OAuthCheckResponse'] | unknown;
+					'application/json': unknown;
 				};
 			};
-			/** @description Bad request syntax or unsupported method */
+			/** @description Test credentials missing or session already redeemed. */
 			400: {
 				headers: {
 					[name: string]: unknown;
 				};
 				content: {
-					'application/json': {
-						status_code: number;
-						detail: string;
-						extra?:
-							| null
-							| {
-									[key: string]: unknown;
-							  }
-							| unknown[];
-					};
+					'application/json': components['schemas']['ErrorResponse'];
 				};
 			};
 		};
@@ -3027,13 +3143,13 @@ export interface operations {
 			};
 		};
 		responses: {
-			/** @description Document created, URL follows */
-			201: {
+			/** @description Request fulfilled, document follows */
+			200: {
 				headers: {
 					[name: string]: unknown;
 				};
 				content: {
-					'application/json': unknown;
+					'application/json': components['schemas']['SyncResult'];
 				};
 			};
 			/** @description Bad request syntax or unsupported method */
@@ -3052,6 +3168,15 @@ export interface operations {
 							  }
 							| unknown[];
 					};
+				};
+			};
+			/** @description Media server unreachable. */
+			503: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
 				};
 			};
 		};

--- a/frontend/src/routes/(admin)/servers/[id]/+page.svelte
+++ b/frontend/src/routes/(admin)/servers/[id]/+page.svelte
@@ -176,7 +176,7 @@ async function handleUserSync() {
 		}
 
 		if (result.data) {
-			userSyncResult = result.data as SyncResult;
+			userSyncResult = result.data;
 			showUserSyncDialog = true;
 			showSuccess("User sync completed successfully");
 			await invalidateAll();


### PR DESCRIPTION
## Summary

Follow-up to #173. Two pre-existing issues were called out as out of scope there; this PR resolves both.

1. **The `Type Checking` job has been silently skipping `svelte-check` for the entire lifetime of the workflow.** `.github/workflows/code-quality.yml` invokes `bun --cwd frontend run check`. With `--cwd` placed *before* `run`, bun treats it as an unrecognized top-level flag, prints its usage banner to stdout, and exits 0. Net effect: zero TypeScript errors are ever surfaced by CI. The same anti-pattern was live in two pre-commit hooks. Verified against the run logs of #173 (the step completed in roughly 50 ms).
2. **The OpenAPI-generated `frontend/src/lib/api/types.d.ts` declared `OAuthPinResponse | unknown` and `OAuthCheckResponse | unknown`.** Three OAuth endpoints in `backend/src/zondarr/api/oauth.py` annotated returns as `<TypedStruct> | Response[ErrorResponse]`. Litestar cannot infer a status code for the bare `Response[ErrorResponse]` arm, folds it into the 200 schema as `unknown`, and the union collapses to `unknown` downstream. The same issue affected `sync_server` in `backend/src/zondarr/api/servers.py`, which was papered over with a hand-written `SyncResult` interface and an `as SyncResult` cast at the call site.

Re-enabling `svelte-check` without addressing the schema would fail CI immediately, so both fixes ship together.

## Changes

### CI / tooling

- Standardise on `bun run --cwd <dir> <script>` in `code-quality.yml`, both `.pre-commit-config.yaml` hooks (`typecheck-ts`, `tests-ts`), and the `CLAUDE.md` reference. This matches the only working invocation in the repo (`code-quality.yml` test job and `CLAUDE.md` line 59).

### Backend OAuth refactor (`api/oauth.py`)

- `create_pin` and `check_pin`: drop the inline `Response(ErrorResponse(...), status_code=HTTP_502_BAD_GATEWAY)` returns; raise `ExternalServiceError(provider, exc.message, original=exc)` instead. The existing `external_service_error_handler` (already registered in `app.py`) maps it to HTTP 502 with the same wire shape, plus a `correlation_id` (optional field, no consumer asserts on its absence).
- `test_complete_pin`: keeps its `Response[OAuthCheckResponse] | Response[ErrorResponse]` union but wraps every success arm in `Response(..., status_code=HTTP_200_OK)` so Litestar can score both arms. The 400 entry is documented via `responses=`.
- All three handlers gain a `responses=` decorator entry so the OpenAPI schema exposes the alternate status codes (502 for the first two, 400 for the third) without participating in the 200 schema.
- `finally: await flow.close()` blocks unchanged — `raise` and `return` have identical `finally` semantics, so the existing `mock_flow.close.assert_called_once()` assertions hold.

### Backend sync refactor (`api/servers.py`)

- New domain exception `MediaServerUnreachableError` in `core/exceptions.py` (error code `SERVER_UNREACHABLE`) and matching `media_server_unreachable_error_handler` in `api/errors.py` returning HTTP 503. Registered in `app.py` between `ExternalServiceError` and the catch-all `Exception` handler.
- `sync_server` now returns `Response[SyncResult]` and raises `MediaServerUnreachableError` from its `MediaClientError` handler. The pre-existing `_record_sync_run(..., status="failed", ...)` side effect runs *before* the raise, preserving the failed-sync record for the dashboard.
- Pinned `status_code=HTTP_200_OK` on the `@post` decorator. The endpoint previously emitted 201 (Litestar's default for `@post`) which did not match runtime intent — the controller returns a `SyncResult`, not a created resource.

### Frontend cleanup

- `frontend/src/lib/api/types.d.ts` regenerated. The `| unknown` collapse is gone; `SyncResult`, `OAuthPinResponse`, and `OAuthCheckResponse` are now typed precisely.
- `frontend/src/lib/api/client.ts`: replaced the hand-written `SyncResult` interface (and its leading TODO comment) with `export type SyncResult = components['schemas']['SyncResult']`.
- `frontend/src/routes/(admin)/servers/[id]/+page.svelte`: dropped the now-redundant `as SyncResult` cast.

### Tests

- `backend/tests/test_oauth_controller_errors.py`: the test fixture builds a Litestar instance directly without registering exception handlers; with the inline `Response` removed, raised `ExternalServiceError` would have surfaced as 500. Registered `ExternalServiceError` and `NotFoundError` handlers in `_make_test_app` so the four 502 / `flow_closed_on_error` assertions hold.
- `backend/tests/test_server_sync_status.py`: updated the manual sync integration test from `assert response.status_code == 201` to `200` to match the new explicit `status_code=HTTP_200_OK`.

## Verification

Local results on a fresh checkout of this branch:

| Gate | Result |
|------|--------|
| `bun run --cwd frontend check` | 0 errors, 0 warnings, 5083 files |
| `cd backend && uv run basedpyright` | 0 errors, 0 warnings, 0 notes |
| `cd backend && uv run pytest` | 756 passed |
| `bun run --cwd frontend test` | 302 passed (31 files) |
| `prek run --all-files --hook-stage pre-push` | All hooks pass, including `TypeScript Check` (now actually invoking `svelte-check`) |

The `TypeScript Check` hook output now contains `svelte-kit sync && svelte-check ...` followed by `START`/`COMPLETED` lines from svelte-check itself, instead of the bun usage banner.

## Test plan

- [ ] `Type Checking` job log shows real svelte-check output (not the `Usage: bun run [flags]` banner) and takes longer than ~1 second.
- [ ] All four backend test suites green (pytest, basedpyright, ruff, alembic check).
- [ ] All frontend gates green (vitest, biome, svelte-check).
- [ ] Manual smoke: trigger the Plex OAuth join flow against an unreachable Plex URL — frontend renders the existing 502 toast unchanged.
- [ ] Manual smoke: trigger user sync against an unreachable media server — frontend renders the 503 toast unchanged.

## Risks and edge cases

- `correlation_id` is now populated on OAuth 502 responses (it was omitted by the inline path). The field is `Optional` on `ErrorResponse` and no test or frontend caller asserts on its absence — net UX improvement.
- The `error_code` strings (`EXTERNAL_SERVICE_ERROR`, `SERVER_UNREACHABLE`) are unchanged and not consumed by frontend logic (`rg "EXTERNAL_SERVICE_ERROR |SERVER_UNREACHABLE" frontend/src` returns nothing).
- The `tests-ts` pre-commit hook was *also* silently passing before this change. After the fix it actually runs vitest on push; verified locally that the suite is currently green.
- After this PR, no API endpoint in the codebase uses the `Response[Foo] | Response[ErrorResponse]` anti-pattern. The five exception handlers in `api/errors.py` continue to use `Response[ErrorResponse]` — that is the correct usage there.