### PR TITLE
fix: address dogfood findings 001-005

### DIFF
--- a/backend/src/zondarr/api/auth.py
+++ b/backend/src/zondarr/api/auth.py
@@ -312,7 +312,7 @@ class AuthController(Controller):
             store = OAuthSessionStore()
             result = await store.redeem(session, redemption_token)
             if result is not None:
-                redeemed_provider, auth_token = result
+                redeemed_provider, auth_token, _ = result
                 if redeemed_provider != method:
                     raise AuthenticationError(
                         "Redemption token provider mismatch",
@@ -541,7 +541,7 @@ class AuthController(Controller):
             store = OAuthSessionStore()
             result = await store.redeem(session, redemption_token)
             if result is not None:
-                redeemed_provider, auth_token = result
+                redeemed_provider, auth_token, _ = result
                 if redeemed_provider != data.method:
                     raise AuthenticationError(
                         "Redemption token provider mismatch",

--- a/backend/src/zondarr/api/join.py
+++ b/backend/src/zondarr/api/join.py
@@ -339,11 +339,12 @@ class JoinController(Controller):
         # path where the user never types an email but Plex returned one.
         auth_token: str | None = None
         oauth_email: str | None = None
+        oauth_provider: str | None = None
         if data.redemption_token:
             store = OAuthSessionStore()
             result = await store.redeem(session, data.redemption_token)
             if result is not None:
-                _provider, auth_token, oauth_email = result
+                oauth_provider, auth_token, oauth_email = result
 
         identity, users = await redemption_service.redeem(
             code,
@@ -351,6 +352,7 @@ class JoinController(Controller):
             password=data.password,
             email=data.email or oauth_email,
             auth_token=auth_token,
+            oauth_provider=oauth_provider,
             pre_wizard_token=data.pre_wizard_token,
             secret_key=settings.secret_key,
         )

--- a/backend/src/zondarr/api/join.py
+++ b/backend/src/zondarr/api/join.py
@@ -333,19 +333,23 @@ class JoinController(Controller):
         Returns:
             RedemptionResponse on success with identity_id and users_created.
         """
-        # Resolve redemption_token to a real auth_token server-side
+        # Resolve redemption_token to a real auth_token (and provider-supplied
+        # email) server-side. The email is consumed below as a fallback when
+        # the redemption form did not include one — important for the OAuth
+        # path where the user never types an email but Plex returned one.
         auth_token: str | None = None
+        oauth_email: str | None = None
         if data.redemption_token:
             store = OAuthSessionStore()
             result = await store.redeem(session, data.redemption_token)
             if result is not None:
-                _provider, auth_token = result
+                _provider, auth_token, oauth_email = result
 
         identity, users = await redemption_service.redeem(
             code,
             username=data.username,
             password=data.password,
-            email=data.email,
+            email=data.email or oauth_email,
             auth_token=auth_token,
             pre_wizard_token=data.pre_wizard_token,
             secret_key=settings.secret_key,
@@ -363,6 +367,7 @@ class JoinController(Controller):
                 external_user_type=user.external_user_type,
                 expires_at=user.expires_at,
                 updated_at=user.updated_at,
+                email=user.identity.email if user.identity else None,
             )
             for user in users
         ]

--- a/backend/src/zondarr/api/join.py
+++ b/backend/src/zondarr/api/join.py
@@ -367,7 +367,7 @@ class JoinController(Controller):
                 external_user_type=user.external_user_type,
                 expires_at=user.expires_at,
                 updated_at=user.updated_at,
-                email=user.identity.email if user.identity else None,
+                email=identity.email,
             )
             for user in users
         ]

--- a/backend/src/zondarr/api/schemas.py
+++ b/backend/src/zondarr/api/schemas.py
@@ -956,6 +956,8 @@ class UserResponse(msgspec.Struct, omit_defaults=True):
         media_server_id: ID of the media server.
         external_user_id: The user's ID on the media server.
         username: The username on the media server.
+        email: Email captured for the parent identity (OAuth-supplied or
+            user-entered), or None if unknown.
         expires_at: Optional expiration timestamp.
         enabled: Whether the user account is currently active.
         created_at: When the user was created.
@@ -969,6 +971,7 @@ class UserResponse(msgspec.Struct, omit_defaults=True):
     username: str
     enabled: bool
     created_at: datetime
+    email: str | None = None
     external_user_type: str | None = None
     expires_at: datetime | None = None
     updated_at: datetime | None = None

--- a/backend/src/zondarr/app.py
+++ b/backend/src/zondarr/app.py
@@ -76,7 +76,11 @@ from zondarr.core.exceptions import (
     RedemptionError,
     ValidationError,
 )
-from zondarr.core.log_buffer import capture_log_processor, log_buffer
+from zondarr.core.log_buffer import (
+    capture_log_processor,
+    log_buffer,
+    normalize_content_type_processor,
+)
 from zondarr.core.tasks import background_tasks_lifespan
 from zondarr.media.providers import register_all_providers
 from zondarr.media.registry import registry
@@ -140,7 +144,9 @@ def _create_structlog_config() -> StructlogConfig:
 
     Inserts ``capture_log_processor`` before the final renderer so that
     enriched event dicts (with timestamp, level, contextvars) are captured
-    into the in-memory log buffer for SSE streaming.
+    into the in-memory log buffer for SSE streaming. A small normaliser
+    runs first to flatten Litestar's tuple-shaped ``content_type`` to a
+    plain mimetype string.
 
     Configures ``middleware_logging_config`` to:
     - Exclude the SSE log stream endpoint (prevents feedback loop)
@@ -155,10 +161,13 @@ def _create_structlog_config() -> StructlogConfig:
     base = _StructLoggingConfig()
     processors: list[Processor] = list(base.processors) if base.processors else []
 
-    # Insert capture processor before the final renderer
+    # Insert content_type normaliser, then capture processor, before the
+    # final renderer so the buffer sees the cleaned value.
     if len(processors) >= 1:
+        processors.insert(-1, normalize_content_type_processor)
         processors.insert(-1, capture_log_processor)
     else:
+        processors.append(normalize_content_type_processor)
         processors.append(capture_log_processor)
 
     return StructlogConfig(

--- a/backend/src/zondarr/core/log_buffer.py
+++ b/backend/src/zondarr/core/log_buffer.py
@@ -184,6 +184,26 @@ def _truncate(value: str, max_len: int) -> str:
     return value[: max_len - 3] + "..."
 
 
+def normalize_content_type_processor(
+    _logger: WrappedLogger,  # pyright: ignore[reportExplicitAny,reportAny]
+    _method_name: str,
+    event_dict: EventDict,
+) -> EventDict:
+    """Flatten Litestar's tuple-shaped ``content_type`` to its mimetype string.
+
+    Litestar's ``request.content_type`` is ``(mimetype, params)``; the params
+    dict is rarely useful in a log line and renders as a Python repr.
+    Replace the tuple with just the mimetype so log lines read
+    ``content_type=application/json`` instead of
+    ``content_type=('application/json', {})``.
+    """
+    ct: object = event_dict.get("content_type")
+    if isinstance(ct, tuple) and ct:
+        first: object = ct[0]  # pyright: ignore[reportUnknownVariableType]
+        event_dict["content_type"] = first if isinstance(first, str) else ""
+    return event_dict
+
+
 def capture_log_processor(
     _logger: WrappedLogger,  # pyright: ignore[reportExplicitAny,reportAny]
     _method_name: str,

--- a/backend/src/zondarr/services/oauth_session.py
+++ b/backend/src/zondarr/services/oauth_session.py
@@ -171,19 +171,27 @@ class OAuthSessionStore:
         self,
         session: AsyncSession,
         redemption_token: str,
-    ) -> tuple[str, str] | None:
-        """Consume a redemption token and return (provider, auth_token).
+    ) -> tuple[str, str, str | None] | None:
+        """Consume a redemption token and return (provider, auth_token, email).
 
         One-time use: after redemption the token is invalidated.
         Uses a conditional UPDATE to atomically mark the token as redeemed,
         preventing double-redemption under concurrent requests.
+
+        The email captured during OAuth (e.g. from Plex's user endpoint) is
+        returned alongside so callers can populate ``Identity.email`` without
+        a separate lookup. The email column is preserved in storage after
+        redemption — it is not a secret and helps audit who redeemed which
+        invitation.
 
         Args:
             session: SQLAlchemy async session.
             redemption_token: The one-time redemption token.
 
         Returns:
-            A (provider, auth_token) tuple, or None if invalid/already used.
+            A (provider, auth_token, email) tuple where ``email`` may be
+            ``None`` if the provider did not supply one, or ``None`` if the
+            token is invalid/already used/expired.
         """
         # Atomically claim the token: only one concurrent request can
         # match redeemed=False and flip it to True.
@@ -199,6 +207,7 @@ class OAuthSessionStore:
                 OAuthSessionModel.handle,
                 OAuthSessionModel.provider,
                 OAuthSessionModel.auth_token,
+                OAuthSessionModel.email,
                 OAuthSessionModel.created_at,
                 OAuthSessionModel.ttl,
             )
@@ -209,10 +218,12 @@ class OAuthSessionStore:
         handle: str = row.handle  # pyright: ignore[reportAny]
         provider: str = row.provider  # pyright: ignore[reportAny]
         auth_token: str = row.auth_token  # pyright: ignore[reportAny]
+        email: str | None = row.email  # pyright: ignore[reportAny]
         # Check TTL expiry (can't easily express in SQL portably)
         if self._is_expired_raw(row.created_at, row.ttl):  # pyright: ignore[reportAny]
             return None
-        # Clear auth_token from storage after reading it
+        # Clear auth_token from storage after reading it. Email is kept so
+        # operators can audit which user redeemed which invitation.
         clear_stmt = (
             update(OAuthSessionModel)
             .where(OAuthSessionModel.redemption_token == redemption_token)
@@ -225,7 +236,7 @@ class OAuthSessionStore:
             handle_prefix=handle[:8],
             provider=provider,
         )
-        return (provider, auth_token)
+        return (provider, auth_token, email)
 
     async def remove(
         self,

--- a/backend/src/zondarr/services/redemption.py
+++ b/backend/src/zondarr/services/redemption.py
@@ -203,7 +203,18 @@ class RedemptionService:
                     "OAuth authentication is required for this invitation",
                     redemption_error_code="OAUTH_REQUIRED",
                 )
-            if oauth_provider is not None and oauth_provider != server.server_type:
+            if oauth_provider is None:
+                # ``auth_token`` without a paired ``oauth_provider`` violates
+                # the keyword-arg contract (see docstring). Treat as a missing
+                # provider rather than silently accepting the token, so a
+                # token issued for one provider can never be replayed against
+                # an invitation targeting another.
+                raise RedemptionError(
+                    "OAuth provider is required when an auth token is supplied",
+                    redemption_error_code="OAUTH_PROVIDER_REQUIRED",
+                    failed_server=server.name,
+                )
+            if oauth_provider != server.server_type:
                 raise RedemptionError(
                     "Redemption token provider does not match invitation target",
                     redemption_error_code="OAUTH_PROVIDER_MISMATCH",

--- a/backend/src/zondarr/services/redemption.py
+++ b/backend/src/zondarr/services/redemption.py
@@ -115,6 +115,7 @@ class RedemptionService:
         password: str,
         email: str | None = None,
         auth_token: str | None = None,
+        oauth_provider: str | None = None,
         pre_wizard_token: str | None = None,
         secret_key: str | None = None,
     ) -> tuple[Identity, Sequence[User]]:
@@ -140,6 +141,10 @@ class RedemptionService:
             password: Password for the new accounts (keyword-only).
             email: Optional email address (keyword-only).
             auth_token: Optional auth token for OAuth flows (keyword-only).
+            oauth_provider: Provider that issued ``auth_token`` (e.g.
+                ``"plex"``). Required when ``auth_token`` is supplied so the
+                redemption can verify the OAuth session matches the
+                invitation's OAuth-requiring target server (keyword-only).
             pre_wizard_token: Signed wizard completion token (keyword-only).
             secret_key: App secret key for verifying wizard tokens (keyword-only).
 
@@ -177,19 +182,33 @@ class RedemptionService:
                     redemption_error_code="WIZARD_REQUIRED",
                 )
 
-        # Step 2.75: Require OAuth token for servers that use OAuth join flow
-        if auth_token is None:
-            for server in invitation.target_servers:
-                provider = registry.get_provider(server.server_type)
-                join_flow = provider.join_flow
-                if (
-                    join_flow is not None
-                    and join_flow.flow_type == JoinFlowType.OAUTH_LINK
-                ):
-                    raise RedemptionError(
-                        "OAuth authentication is required for this invitation",
-                        redemption_error_code="OAUTH_REQUIRED",
-                    )
+        # Step 2.75: Validate OAuth requirements for each target server.
+        # - If the server uses an OAUTH_LINK join flow, an auth_token is
+        #   required (OAUTH_REQUIRED).
+        # - If a token was supplied, the originating provider must match the
+        #   server type (OAUTH_PROVIDER_MISMATCH). This mirrors the guard in
+        #   ``api/auth.py`` for admin-login / link-provider and prevents a
+        #   redemption token issued for one provider from being silently
+        #   accepted against an invitation targeting another.
+        for server in invitation.target_servers:
+            provider = registry.get_provider(server.server_type)
+            join_flow = provider.join_flow
+            requires_oauth = (
+                join_flow is not None and join_flow.flow_type == JoinFlowType.OAUTH_LINK
+            )
+            if not requires_oauth:
+                continue
+            if auth_token is None:
+                raise RedemptionError(
+                    "OAuth authentication is required for this invitation",
+                    redemption_error_code="OAUTH_REQUIRED",
+                )
+            if oauth_provider is not None and oauth_provider != server.server_type:
+                raise RedemptionError(
+                    "Redemption token provider does not match invitation target",
+                    redemption_error_code="OAUTH_PROVIDER_MISMATCH",
+                    failed_server=server.name,
+                )
 
         # Step 2.8: Check username uniqueness across target servers
         for server in invitation.target_servers:

--- a/backend/tests/test_log_buffer_processors.py
+++ b/backend/tests/test_log_buffer_processors.py
@@ -1,0 +1,83 @@
+"""Tests for the structlog content_type normaliser.
+
+Litestar's ``request.content_type`` is ``(mimetype, params)``. The structlog
+processor at ``zondarr.core.log_buffer.normalize_content_type_processor``
+flattens the tuple to its mimetype string so log lines render as
+``content_type=application/json`` instead of ``content_type=('', {})``.
+"""
+
+from collections.abc import MutableMapping
+
+from zondarr.core.log_buffer import normalize_content_type_processor
+
+
+def _run(event_dict: MutableMapping[str, object]) -> MutableMapping[str, object]:
+    """Invoke the processor with dummy logger/name; return the mutated dict."""
+    return normalize_content_type_processor(None, "info", event_dict)
+
+
+def test_flattens_populated_content_type_tuple() -> None:
+    event_dict: MutableMapping[str, object] = {
+        "event": "HTTP Request",
+        "method": "POST",
+        "content_type": ("application/json", {"charset": "utf-8"}),
+    }
+    out = _run(event_dict)
+    assert out["content_type"] == "application/json"
+    assert out["method"] == "POST"
+    assert out["event"] == "HTTP Request"
+
+
+def test_flattens_empty_content_type_tuple_to_empty_string() -> None:
+    event_dict: MutableMapping[str, object] = {
+        "event": "HTTP Request",
+        "content_type": ("", {}),
+    }
+    out = _run(event_dict)
+    assert out["content_type"] == ""
+
+
+def test_passes_through_string_content_type_unchanged() -> None:
+    event_dict: MutableMapping[str, object] = {
+        "event": "HTTP Request",
+        "content_type": "text/plain",
+    }
+    out = _run(event_dict)
+    assert out["content_type"] == "text/plain"
+
+
+def test_does_not_add_content_type_when_missing() -> None:
+    event_dict: MutableMapping[str, object] = {
+        "event": "HTTP Response",
+        "status_code": 200,
+    }
+    out = _run(event_dict)
+    assert "content_type" not in out
+    assert out["status_code"] == 200
+
+
+def test_handles_non_string_first_tuple_element() -> None:
+    """Defensive: if Litestar ever puts something weird in slot 0, fall back to ''."""
+    event_dict: MutableMapping[str, object] = {
+        "event": "HTTP Request",
+        "content_type": (None, {}),
+    }
+    out = _run(event_dict)
+    assert out["content_type"] == ""
+
+
+def test_other_fields_are_preserved() -> None:
+    event_dict: MutableMapping[str, object] = {
+        "event": "HTTP Request",
+        "method": "GET",
+        "path": "/api/v1/users",
+        "query": {"page": "1"},
+        "path_params": {},
+        "content_type": ("application/json", {}),
+    }
+    out = _run(event_dict)
+    assert out["method"] == "GET"
+    assert out["path"] == "/api/v1/users"
+    assert out["query"] == {"page": "1"}
+    assert out["path_params"] == {}
+    assert out["content_type"] == "application/json"

--- a/backend/tests/test_oauth_session.py
+++ b/backend/tests/test_oauth_session.py
@@ -106,7 +106,7 @@ class TestAuthentication:
 class TestOneTimeRedemption:
     """Redemption tokens are consumed once."""
 
-    async def test_redeem_returns_provider_and_auth_token(
+    async def test_redeem_returns_provider_auth_token_and_email(
         self, store: OAuthSessionStore, session: AsyncSession
     ) -> None:
         handle = await store.create(session, "plex", 1)
@@ -116,9 +116,39 @@ class TestOneTimeRedemption:
         assert redemption_token is not None
         result = await store.redeem(session, redemption_token)
         assert result is not None
-        provider, auth_token = result
+        provider, auth_token, email = result
         assert provider == "plex"
         assert auth_token == "raw_token_abc"  # noqa: S105
+        assert email == "a@b.com"
+
+    async def test_redeem_returns_none_email_when_not_supplied(
+        self, store: OAuthSessionStore, session: AsyncSession
+    ) -> None:
+        handle = await store.create(session, "plex", 1)
+        redemption_token = await store.set_authenticated(
+            session, handle, auth_token="raw_token_abc", email=None
+        )
+        assert redemption_token is not None
+        result = await store.redeem(session, redemption_token)
+        assert result is not None
+        provider, auth_token, email = result
+        assert provider == "plex"
+        assert auth_token == "raw_token_abc"  # noqa: S105
+        assert email is None
+
+    async def test_redeem_preserves_email_after_consumption(
+        self, store: OAuthSessionStore, session: AsyncSession
+    ) -> None:
+        """Email is kept on the session after redemption for audit."""
+        handle = await store.create(session, "plex", 1)
+        redemption_token = await store.set_authenticated(
+            session, handle, auth_token="x", email="audit@example.com"
+        )
+        assert redemption_token is not None
+        _ = await store.redeem(session, redemption_token)
+        oauth_session = await store.get(session, handle)
+        assert oauth_session is not None
+        assert oauth_session.email == "audit@example.com"
 
     async def test_redeem_clears_auth_token_from_session(
         self, store: OAuthSessionStore, session: AsyncSession

--- a/frontend/src/lib/components/dashboard/stat-card-test-harness.svelte
+++ b/frontend/src/lib/components/dashboard/stat-card-test-harness.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import StatCard from './stat-card.svelte';
+
+interface Props {
+	title: string;
+	value: number | string;
+	subtitle?: string;
+}
+
+const { title, value, subtitle }: Props = $props();
+</script>
+
+<StatCard {title} {value} {subtitle}>
+	{#snippet icon()}
+		<span data-testid="harness-icon" class="size-4">i</span>
+	{/snippet}
+</StatCard>

--- a/frontend/src/lib/components/dashboard/stat-card.svelte
+++ b/frontend/src/lib/components/dashboard/stat-card.svelte
@@ -15,8 +15,8 @@
 
 <Card.Root class="border-cr-border bg-cr-surface transition-colors hover:border-cr-accent/20">
 	<Card.Content class="pt-6">
-		<div class="flex items-start justify-between">
-			<div class="space-y-1">
+		<div class="flex items-start justify-between gap-3 min-w-0">
+			<div class="space-y-1 min-w-0">
 				<p class="text-sm font-medium text-cr-text-muted">{title}</p>
 				<p class="text-3xl font-bold font-display text-cr-text tracking-tight">{value}</p>
 				{#if subtitle}

--- a/frontend/src/lib/components/dashboard/stat-card.svelte.test.ts
+++ b/frontend/src/lib/components/dashboard/stat-card.svelte.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for StatCard component layout safeguards.
+ *
+ * Asserts the flex container and inner text wrapper have the min-w-0 / gap-3
+ * classes that prevent the dashboard from overflowing horizontally on narrow
+ * viewports (see ISSUE-003 in the dogfood report).
+ *
+ * @module $lib/components/dashboard/stat-card.svelte.test
+ */
+
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import StatCardTestHarness from './stat-card-test-harness.svelte';
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('StatCard', () => {
+	it('should apply min-w-0 and gap-3 to the inner flex row', () => {
+		const { container } = render(StatCardTestHarness, {
+			props: {
+				title: 'Active Users',
+				value: 42,
+				subtitle: 'last 7 days'
+			}
+		});
+
+		const flexRow = container.querySelector('div.flex.items-start.justify-between');
+		expect(flexRow).not.toBeNull();
+		expect(flexRow?.classList.contains('min-w-0')).toBe(true);
+		expect(flexRow?.classList.contains('gap-3')).toBe(true);
+	});
+
+	it('should apply min-w-0 to the title/value text wrapper', () => {
+		const { container } = render(StatCardTestHarness, {
+			props: {
+				title: 'Active Users',
+				value: 42
+			}
+		});
+
+		// The text wrapper is the first child of the flex row, with space-y-1.
+		const textWrapper = container.querySelector('div.space-y-1');
+		expect(textWrapper).not.toBeNull();
+		expect(textWrapper?.classList.contains('min-w-0')).toBe(true);
+	});
+});

--- a/frontend/src/lib/components/invitations/invitation-row.svelte
+++ b/frontend/src/lib/components/invitations/invitation-row.svelte
@@ -33,18 +33,40 @@ interface Props {
 const { invitation, onEdit, onDelete }: Props = $props();
 
 /**
+ * True when the invitation has a max_uses cap that's been fully consumed.
+ * "Used up" beats the generic "Expired" so admins can tell why redemption
+ * is blocked.
+ */
+const isUsedUp = $derived(
+	invitation.max_uses != null &&
+		invitation.remaining_uses != null &&
+		invitation.remaining_uses <= 0,
+);
+
+/**
+ * True when the invitation has an expiry date in the past.
+ */
+const isDateExpired = $derived(
+	invitation.expires_at != null &&
+		new Date(invitation.expires_at).getTime() < Date.now(),
+);
+
+/**
  * Derive the status for the badge based on invitation state.
+ * Both "used up" and "date expired" share the visually expired styling, but
+ * are labelled differently below so admins can distinguish them.
  */
 const status = $derived.by((): StatusBadgeStatus => {
 	if (!invitation.enabled) return "disabled";
+	if (isUsedUp) return "expired";
+	if (isDateExpired) return "expired";
 	if (!invitation.is_active) return "expired";
-	// Check if limited (has max_uses and getting close)
 	if (
 		invitation.remaining_uses !== null &&
-		invitation.remaining_uses !== undefined
+		invitation.remaining_uses !== undefined &&
+		invitation.remaining_uses <= 3
 	) {
-		if (invitation.remaining_uses <= 0) return "expired";
-		if (invitation.remaining_uses <= 3) return "limited";
+		return "limited";
 	}
 	return "active";
 });
@@ -54,13 +76,15 @@ const status = $derived.by((): StatusBadgeStatus => {
  */
 const statusLabel = $derived.by(() => {
 	if (!invitation.enabled) return "Disabled";
-	if (!invitation.is_active) return "Expired";
+	if (isUsedUp) return "Used up";
+	if (isDateExpired) return "Expired";
+	if (!invitation.is_active) return "Inactive";
 	if (
 		invitation.remaining_uses !== null &&
-		invitation.remaining_uses !== undefined
+		invitation.remaining_uses !== undefined &&
+		invitation.remaining_uses <= 3
 	) {
-		if (invitation.remaining_uses <= 0) return "Exhausted";
-		if (invitation.remaining_uses <= 3) return "Limited";
+		return "Limited";
 	}
 	return "Active";
 });

--- a/frontend/src/lib/components/invitations/invitation-row.svelte
+++ b/frontend/src/lib/components/invitations/invitation-row.svelte
@@ -44,22 +44,14 @@ const isUsedUp = $derived(
 );
 
 /**
- * True when the invitation has an expiry date in the past.
- */
-const isDateExpired = $derived(
-	invitation.expires_at != null &&
-		new Date(invitation.expires_at).getTime() < Date.now(),
-);
-
-/**
  * Derive the status for the badge based on invitation state.
- * Both "used up" and "date expired" share the visually expired styling, but
- * are labelled differently below so admins can distinguish them.
+ * "Used up" is distinguished from the generic inactive state so admins can
+ * see the specific reason redemption is blocked. Date-expiry is delegated to
+ * the server via `is_active` to avoid client-clock-skew false positives.
  */
 const status = $derived.by((): StatusBadgeStatus => {
 	if (!invitation.enabled) return "disabled";
 	if (isUsedUp) return "expired";
-	if (isDateExpired) return "expired";
 	if (!invitation.is_active) return "expired";
 	if (
 		invitation.remaining_uses !== null &&
@@ -77,7 +69,6 @@ const status = $derived.by((): StatusBadgeStatus => {
 const statusLabel = $derived.by(() => {
 	if (!invitation.enabled) return "Disabled";
 	if (isUsedUp) return "Used up";
-	if (isDateExpired) return "Expired";
 	if (!invitation.is_active) return "Inactive";
 	if (
 		invitation.remaining_uses !== null &&

--- a/frontend/src/lib/components/invitations/invitation-row.svelte
+++ b/frontend/src/lib/components/invitations/invitation-row.svelte
@@ -69,7 +69,7 @@ const status = $derived.by((): StatusBadgeStatus => {
 const statusLabel = $derived.by(() => {
 	if (!invitation.enabled) return "Disabled";
 	if (isUsedUp) return "Used up";
-	if (!invitation.is_active) return "Inactive";
+	if (!invitation.is_active) return "Expired";
 	if (
 		invitation.remaining_uses !== null &&
 		invitation.remaining_uses !== undefined &&

--- a/frontend/src/lib/components/invitations/invitation-row.svelte.test.ts
+++ b/frontend/src/lib/components/invitations/invitation-row.svelte.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the InvitationRow status badge logic.
+ *
+ * Verifies that "used up" (max_uses exhausted) is distinguished from
+ * "expired" (date past), addressing dogfood ISSUE-004.
+ *
+ * @module $lib/components/invitations/invitation-row.svelte.test
+ */
+
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { InvitationResponse } from '$lib/api/client';
+import InvitationRow from './invitation-row.svelte';
+
+afterEach(() => {
+	cleanup();
+});
+
+const HOUR = 60 * 60 * 1000;
+
+function makeInvitation(overrides: Partial<InvitationResponse> = {}): InvitationResponse {
+	return {
+		id: '00000000-0000-0000-0000-000000000001',
+		code: 'TESTCODE',
+		use_count: 0,
+		enabled: true,
+		created_at: new Date(Date.now() - 24 * HOUR).toISOString(),
+		expires_at: new Date(Date.now() + 24 * HOUR).toISOString(),
+		max_uses: null,
+		duration_days: null,
+		created_by: null,
+		updated_at: null,
+		is_active: true,
+		remaining_uses: null,
+		...overrides
+	};
+}
+
+function getStatusInfo(invitation: InvitationResponse): {
+	status: string | null;
+	label: string;
+} {
+	const { container } = render(InvitationRow, { props: { invitation } });
+	const badge = container.querySelector('[data-status-badge]');
+	return {
+		status: badge?.getAttribute('data-status') ?? null,
+		label: badge?.textContent?.trim() ?? ''
+	};
+}
+
+describe('InvitationRow status badge', () => {
+	it('should label disabled invitations "Disabled"', () => {
+		const inv = makeInvitation({ enabled: false, is_active: false });
+		const info = getStatusInfo(inv);
+		expect(info.status).toBe('disabled');
+		expect(info.label).toContain('Disabled');
+	});
+
+	it('should label a fully-used max_uses=1 invitation "Used up" (not "Expired")', () => {
+		// max_uses reached but expiry is still in the future — distinguishes the
+		// reason for non-redeemability from a date-based expiry.
+		const inv = makeInvitation({
+			max_uses: 1,
+			use_count: 1,
+			remaining_uses: 0,
+			is_active: false,
+			expires_at: new Date(Date.now() + 24 * HOUR).toISOString()
+		});
+		const info = getStatusInfo(inv);
+		expect(info.status).toBe('expired');
+		expect(info.label).toContain('Used up');
+		expect(info.label).not.toContain('Expired');
+	});
+
+	it('should label a date-expired invitation "Expired"', () => {
+		const inv = makeInvitation({
+			max_uses: null,
+			use_count: 5,
+			remaining_uses: null,
+			is_active: false,
+			expires_at: new Date(Date.now() - 24 * HOUR).toISOString()
+		});
+		const info = getStatusInfo(inv);
+		expect(info.status).toBe('expired');
+		expect(info.label).toContain('Expired');
+		expect(info.label).not.toContain('Used up');
+	});
+
+	it('should label a healthy invitation "Active"', () => {
+		const inv = makeInvitation({
+			max_uses: 10,
+			use_count: 1,
+			remaining_uses: 9,
+			is_active: true,
+			expires_at: new Date(Date.now() + 30 * 24 * HOUR).toISOString()
+		});
+		const info = getStatusInfo(inv);
+		expect(info.status).toBe('active');
+		expect(info.label).toContain('Active');
+	});
+
+	it('should label an invitation with few remaining uses "Limited"', () => {
+		const inv = makeInvitation({
+			max_uses: 10,
+			use_count: 8,
+			remaining_uses: 2,
+			is_active: true,
+			expires_at: new Date(Date.now() + 24 * HOUR).toISOString()
+		});
+		const info = getStatusInfo(inv);
+		expect(info.status).toBe('limited');
+		expect(info.label).toContain('Limited');
+	});
+
+	it('should keep an unlimited invitation "Active" regardless of use_count', () => {
+		// remaining_uses=null means no max_uses → never "Used up".
+		const inv = makeInvitation({
+			max_uses: null,
+			use_count: 100,
+			remaining_uses: null,
+			is_active: true,
+			expires_at: new Date(Date.now() + 30 * 24 * HOUR).toISOString()
+		});
+		const info = getStatusInfo(inv);
+		expect(info.status).toBe('active');
+		expect(info.label).toContain('Active');
+	});
+});

--- a/frontend/src/lib/components/invitations/invitation-row.svelte.test.ts
+++ b/frontend/src/lib/components/invitations/invitation-row.svelte.test.ts
@@ -2,8 +2,9 @@
  * Tests for the InvitationRow status badge logic.
  *
  * Verifies that "Used up" (max_uses exhausted, client-derivable) is
- * distinguished from the generic "Inactive" branch (server's is_active=false,
- * cause unknown to the client), addressing dogfood ISSUE-004.
+ * distinguished from the "Expired" branch (server's is_active=false after
+ * the !enabled and isUsedUp checks have already eliminated those causes,
+ * leaving only date expiry), addressing dogfood ISSUE-004.
  *
  * @module $lib/components/invitations/invitation-row.svelte.test
  */
@@ -73,12 +74,13 @@ describe('InvitationRow status badge', () => {
 		expect(info.label).not.toContain('Expired');
 	});
 
-	it('should label a server-inactive invitation "Inactive"', () => {
-		// The server's is_active boolean is the source of truth for whether an
-		// invitation is redeemable. The UI does not guess the cause (e.g.
-		// date-expiry vs. other server-side reasons) because the response only
-		// exposes the boolean, not a reason field. Use "Used up" only when
-		// max_uses is exhausted (a client-derivable signal).
+	it('should label a date-expired invitation "Expired"', () => {
+		// The backend's is_active=False has exactly three causes: !enabled,
+		// expires_at <= now, and use_count >= max_uses. The frontend priority
+		// chain catches !enabled ("Disabled") and use_count >= max_uses
+		// ("Used up") explicitly before reaching this branch, so by
+		// elimination !is_active here implies date expiry. Server-derived to
+		// avoid client-clock-skew false positives.
 		const inv = makeInvitation({
 			max_uses: null,
 			use_count: 5,
@@ -88,7 +90,7 @@ describe('InvitationRow status badge', () => {
 		});
 		const info = getStatusInfo(inv);
 		expect(info.status).toBe('expired');
-		expect(info.label).toContain('Inactive');
+		expect(info.label).toContain('Expired');
 		expect(info.label).not.toContain('Used up');
 	});
 

--- a/frontend/src/lib/components/invitations/invitation-row.svelte.test.ts
+++ b/frontend/src/lib/components/invitations/invitation-row.svelte.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for the InvitationRow status badge logic.
  *
- * Verifies that "used up" (max_uses exhausted) is distinguished from
- * "expired" (date past), addressing dogfood ISSUE-004.
+ * Verifies that "Used up" (max_uses exhausted, client-derivable) is
+ * distinguished from the generic "Inactive" branch (server's is_active=false,
+ * cause unknown to the client), addressing dogfood ISSUE-004.
  *
  * @module $lib/components/invitations/invitation-row.svelte.test
  */
@@ -72,7 +73,12 @@ describe('InvitationRow status badge', () => {
 		expect(info.label).not.toContain('Expired');
 	});
 
-	it('should label a date-expired invitation "Expired"', () => {
+	it('should label a server-inactive invitation "Inactive"', () => {
+		// The server's is_active boolean is the source of truth for whether an
+		// invitation is redeemable. The UI does not guess the cause (e.g.
+		// date-expiry vs. other server-side reasons) because the response only
+		// exposes the boolean, not a reason field. Use "Used up" only when
+		// max_uses is exhausted (a client-derivable signal).
 		const inv = makeInvitation({
 			max_uses: null,
 			use_count: 5,
@@ -82,7 +88,7 @@ describe('InvitationRow status badge', () => {
 		});
 		const info = getStatusInfo(inv);
 		expect(info.status).toBe('expired');
-		expect(info.label).toContain('Expired');
+		expect(info.label).toContain('Inactive');
 		expect(info.label).not.toContain('Used up');
 	});
 

--- a/frontend/src/lib/components/setup/setup-wizard.svelte.test.ts
+++ b/frontend/src/lib/components/setup/setup-wizard.svelte.test.ts
@@ -24,6 +24,7 @@ vi.mock('$lib/api/client', async () => {
 	return {
 		...actual,
 		withErrorHandling: vi.fn(),
+		getCsrfOrigin: vi.fn(),
 		getEnvCredentials: vi.fn(),
 		testCsrfOrigin: vi.fn(),
 		setCsrfOrigin: vi.fn(),
@@ -101,6 +102,11 @@ describe('SetupWizard', () => {
 		});
 
 		vi.mocked(apiClient.withErrorHandling)
+			// StepCsrf's $effect fires getCsrfOrigin on mount
+			.mockResolvedValueOnce({
+				data: { csrf_origin: 'http://localhost:3000', is_locked: false },
+				error: undefined
+			})
 			.mockResolvedValueOnce({
 				data: {
 					success: true,

--- a/frontend/src/lib/components/setup/step-csrf.svelte
+++ b/frontend/src/lib/components/setup/step-csrf.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
-import { Plug, ShieldCheck } from '@lucide/svelte';
+import { Lock, Plug, ShieldCheck } from '@lucide/svelte';
 import { browser } from '$app/environment';
 import type { CsrfOriginTestResponse } from '$lib/api/client';
-import { setCsrfOrigin, testCsrfOrigin, withErrorHandling } from '$lib/api/client';
+import {
+	getCsrfOrigin,
+	setCsrfOrigin,
+	testCsrfOrigin,
+	withErrorHandling
+} from '$lib/api/client';
 import { asErrorResponse } from '$lib/api/errors';
 import ConfirmDialog from '$lib/components/confirm-dialog.svelte';
+import { Badge } from '$lib/components/ui/badge';
 import { Button } from '$lib/components/ui/button';
 import * as Card from '$lib/components/ui/card';
 import { Input } from '$lib/components/ui/input';
@@ -29,12 +35,31 @@ let testing = $state(false);
 let testResult = $state<CsrfOriginTestResponse | null>(null);
 let hasAttemptedTest = $state(false);
 
+// Lock state — env-managed CSRF_ORIGIN cannot be edited from the wizard
+let isLocked = $state(false);
+let lockedSourceLoaded = $state(false);
+
 // Confirmation dialog state
 let showSaveConfirm = $state(false);
 let showSkipConfirm = $state(false);
 
 const canTest = $derived(origin.trim().length > 0);
 const testPassed = $derived(testResult?.success === true);
+
+$effect(() => {
+	(async () => {
+		const result = await withErrorHandling(() => getCsrfOrigin(), {
+			showErrorToast: false
+		});
+		if (result?.data) {
+			isLocked = Boolean(result.data.is_locked);
+			if (result.data.csrf_origin) {
+				origin = result.data.csrf_origin;
+			}
+		}
+		lockedSourceLoaded = true;
+	})();
+});
 
 function onOriginChange() {
 	testResult = null;
@@ -123,9 +148,22 @@ async function handleSubmit() {
 
 <Card.Root class="border-cr-border bg-cr-surface">
 	<Card.Header>
-		<Card.Title class="text-lg text-cr-text">Security Configuration</Card.Title>
+		<div class="flex items-center gap-2">
+			<Card.Title class="text-lg text-cr-text">Security Configuration</Card.Title>
+			{#if isLocked}
+				<Badge variant="secondary" class="gap-1">
+					<Lock class="size-3" />
+					Environment Variable
+				</Badge>
+			{/if}
+		</div>
 		<Card.Description class="text-cr-text-muted">
-			Set your trusted origin for CSRF protection.
+			{#if isLocked}
+				CSRF origin is managed by the <code class="font-mono text-xs">CSRF_ORIGIN</code>
+				environment variable. The current value is shown below and cannot be edited from the wizard.
+			{:else}
+				Set your trusted origin for CSRF protection.
+			{/if}
 		</Card.Description>
 	</Card.Header>
 	<Card.Content>
@@ -157,7 +195,7 @@ async function handleSubmit() {
 					bind:value={origin}
 					oninput={onOriginChange}
 					placeholder="https://zondarr.example.com"
-					disabled={submitting || testing}
+					disabled={isLocked || submitting || testing}
 					class="border-cr-border bg-cr-bg text-cr-text placeholder:text-cr-text-muted/50 focus:border-cr-accent font-mono text-sm"
 				/>
 				<p class="text-xs text-cr-text-muted">
@@ -168,69 +206,87 @@ async function handleSubmit() {
 				{/if}
 			</div>
 
-			<!-- Test Origin -->
-			<div class="space-y-2">
-				<Button
-					type="button"
-					variant="outline"
-					onclick={handleTest}
-					disabled={!canTest || testing || submitting}
-					class="w-full border-cr-border bg-cr-bg text-cr-text hover:bg-cr-border"
-				>
-					{#if testing}
-						<span
-							class="size-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-						></span>
-						Testing...
-					{:else}
-						<Plug class="size-4" />
-						Test Origin
-					{/if}
-				</Button>
+			{#if !isLocked}
+				<!-- Test Origin -->
+				<div class="space-y-2">
+					<Button
+						type="button"
+						variant="outline"
+						onclick={handleTest}
+						disabled={!canTest || testing || submitting}
+						class="w-full border-cr-border bg-cr-bg text-cr-text hover:bg-cr-border"
+					>
+						{#if testing}
+							<span
+								class="size-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+							></span>
+							Testing...
+						{:else}
+							<Plug class="size-4" />
+							Test Origin
+						{/if}
+					</Button>
 
-				{#if testResult}
-					{#if testResult.success}
-						<div
-							class="rounded-md border border-green-500/30 bg-green-500/10 px-3 py-2 text-sm text-green-400"
-						>
-							<p>{testResult.message}</p>
-						</div>
-					{:else}
-						<div
-							class="rounded-md border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-sm text-rose-400"
-						>
-							<p>{testResult.message}</p>
-						</div>
+					{#if testResult}
+						{#if testResult.success}
+							<div
+								class="rounded-md border border-green-500/30 bg-green-500/10 px-3 py-2 text-sm text-green-400"
+							>
+								<p>{testResult.message}</p>
+							</div>
+						{:else}
+							<div
+								class="rounded-md border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-sm text-rose-400"
+							>
+								<p>{testResult.message}</p>
+							</div>
+						{/if}
 					{/if}
-				{/if}
-			</div>
+				</div>
+			{/if}
 
 			<div class="flex items-center justify-between gap-3 border-t border-cr-border pt-4">
-				<Button
-					type="button"
-					variant="ghost"
-					onclick={handleSkipClick}
-					disabled={!hasAttemptedTest || submitting || testing}
-					class="text-cr-text-muted hover:text-cr-text"
-				>
-					Skip for now
-				</Button>
-				<Button
-					type="button"
-					onclick={handleSaveClick}
-					disabled={!hasAttemptedTest || submitting || testing}
-					class="bg-cr-accent text-cr-bg hover:bg-cr-accent-hover"
-				>
-					{#if submitting}
+				{#if !lockedSourceLoaded}
+					<div class="ml-auto">
 						<span
-							class="size-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+							class="block size-4 animate-spin rounded-full border-2 border-current border-t-transparent text-cr-text-muted"
 						></span>
-						Saving...
+					</div>
+				{:else if isLocked}
+					<Button
+						type="button"
+						onclick={onSkip}
+						class="ml-auto bg-cr-accent text-cr-bg hover:bg-cr-accent-hover"
+					>
+						Continue
+					</Button>
+				{:else}
+					<Button
+						type="button"
+						variant="ghost"
+						onclick={handleSkipClick}
+						disabled={!hasAttemptedTest || submitting || testing}
+						class="text-cr-text-muted hover:text-cr-text"
+					>
+						Skip for now
+					</Button>
+					<Button
+						type="button"
+						onclick={handleSaveClick}
+						disabled={!hasAttemptedTest || submitting || testing}
+						class="bg-cr-accent text-cr-bg hover:bg-cr-accent-hover"
+					>
+						{#if submitting}
+							<span
+								class="size-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+							></span>
+							Saving...
 						{:else}
 							Save & Continue
 						{/if}
 					</Button>
-				</div>
+				{/if}
+			</div>
 		</div>
 
 		<p class="mt-3 text-center text-xs text-cr-text-dim">

--- a/frontend/src/lib/components/setup/step-csrf.svelte
+++ b/frontend/src/lib/components/setup/step-csrf.svelte
@@ -219,7 +219,7 @@ async function handleSubmit() {
 					bind:value={origin}
 					oninput={onOriginChange}
 					placeholder="https://zondarr.example.com"
-					disabled={isLocked || submitting || testing}
+					disabled={isLocked || submitting || testing || !lockedSourceLoaded}
 					class="border-cr-border bg-cr-bg text-cr-text placeholder:text-cr-text-muted/50 focus:border-cr-accent font-mono text-sm"
 				/>
 				<p class="text-xs text-cr-text-muted">
@@ -230,7 +230,7 @@ async function handleSubmit() {
 				{/if}
 			</div>
 
-			{#if !isLocked}
+			{#if lockedSourceLoaded && !isLocked}
 				<!-- Test Origin -->
 				<div class="space-y-2">
 					<Button

--- a/frontend/src/lib/components/setup/step-csrf.svelte
+++ b/frontend/src/lib/components/setup/step-csrf.svelte
@@ -38,6 +38,7 @@ let hasAttemptedTest = $state(false);
 // Lock state — env-managed CSRF_ORIGIN cannot be edited from the wizard
 let isLocked = $state(false);
 let lockedSourceLoaded = $state(false);
+let loadError = $state('');
 
 // Confirmation dialog state
 let showSaveConfirm = $state(false);
@@ -46,19 +47,27 @@ let showSkipConfirm = $state(false);
 const canTest = $derived(origin.trim().length > 0);
 const testPassed = $derived(testResult?.success === true);
 
-$effect(() => {
-	(async () => {
-		const result = await withErrorHandling(() => getCsrfOrigin(), {
-			showErrorToast: false
-		});
-		if (result?.data) {
-			isLocked = Boolean(result.data.is_locked);
-			if (result.data.csrf_origin) {
-				origin = result.data.csrf_origin;
-			}
+async function loadLockedSource() {
+	loadError = '';
+	const result = await withErrorHandling(() => getCsrfOrigin(), {
+		showErrorToast: false
+	});
+	if (result?.data) {
+		isLocked = Boolean(result.data.is_locked);
+		if (result.data.csrf_origin) {
+			origin = result.data.csrf_origin;
 		}
-		lockedSourceLoaded = true;
-	})();
+	} else {
+		const errorBody = asErrorResponse(result?.error);
+		loadError =
+			errorBody?.detail ??
+			'Could not load CSRF settings — the lock state is unknown. The backend may be env-locked.';
+	}
+	lockedSourceLoaded = true;
+}
+
+$effect(() => {
+	loadLockedSource();
 });
 
 function onOriginChange() {
@@ -172,6 +181,21 @@ async function handleSubmit() {
 				class="mb-4 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400"
 			>
 				{serverError}
+			</div>
+		{/if}
+
+		{#if loadError}
+			<div
+				class="mb-4 flex items-start justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-400"
+			>
+				<span>{loadError}</span>
+				<button
+					type="button"
+					onclick={loadLockedSource}
+					class="shrink-0 underline hover:text-amber-300"
+				>
+					Retry
+				</button>
 			</div>
 		{/if}
 

--- a/frontend/src/lib/components/setup/step-csrf.svelte.test.ts
+++ b/frontend/src/lib/components/setup/step-csrf.svelte.test.ts
@@ -6,15 +6,16 @@
  * @module $lib/components/setup/step-csrf.svelte.test
  */
 
-import { cleanup, render } from '@testing-library/svelte';
+import { cleanup, render, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('$app/environment', () => ({ browser: true }));
 vi.mock('$lib/api/client', async () => {
 	const actual = await vi.importActual('$lib/api/client');
 	return {
 		...actual,
+		getCsrfOrigin: vi.fn(),
 		setCsrfOrigin: vi.fn(),
 		testCsrfOrigin: vi.fn(),
 		withErrorHandling: vi.fn()
@@ -29,11 +30,29 @@ afterEach(() => {
 	vi.resetAllMocks();
 });
 
+beforeEach(() => {
+	// Default getCsrfOrigin response: not locked. The component's $effect
+	// always issues this call on mount via withErrorHandling, so each test
+	// must enqueue a leading mock for it before the test-specific calls.
+	vi.mocked(apiClient.withErrorHandling).mockResolvedValue({
+		data: { csrf_origin: 'http://localhost:3000', is_locked: false },
+		error: undefined
+	});
+});
+
 /** Helper to find a button by text content. */
 function findButton(container: HTMLElement, text: string): HTMLButtonElement | undefined {
 	return Array.from(container.querySelectorAll('button')).find((b) =>
 		b.textContent?.includes(text)
 	) as HTMLButtonElement | undefined;
+}
+
+/** Mock for the $effect's getCsrfOrigin call. Returns unlocked by default. */
+function mockGetCsrfOriginUnlocked() {
+	vi.mocked(apiClient.withErrorHandling).mockResolvedValueOnce({
+		data: { csrf_origin: 'http://localhost:3000', is_locked: false },
+		error: undefined
+	});
 }
 
 describe('Step CSRF Component', () => {
@@ -57,9 +76,14 @@ describe('Step CSRF Component', () => {
 		expect(input.value).toBe(window.location.origin);
 	});
 
-	it('should render Test, Skip and Save buttons', () => {
+	it('should render Test, Skip and Save buttons', async () => {
 		const { container } = render(StepCsrf, {
 			props: { onComplete: vi.fn(), onSkip: vi.fn() }
+		});
+
+		// Wait for the $effect to settle and footer buttons to appear.
+		await waitFor(() => {
+			expect(findButton(container, 'Save')).toBeTruthy();
 		});
 
 		expect(findButton(container, 'Test Origin')).toBeTruthy();
@@ -67,9 +91,13 @@ describe('Step CSRF Component', () => {
 		expect(findButton(container, 'Save')).toBeTruthy();
 	});
 
-	it('should have Save and Skip disabled before test attempt', () => {
+	it('should have Save and Skip disabled before test attempt', async () => {
 		const { container } = render(StepCsrf, {
 			props: { onComplete: vi.fn(), onSkip: vi.fn() }
+		});
+
+		await waitFor(() => {
+			expect(findButton(container, 'Save')).toBeTruthy();
 		});
 
 		const saveBtn = findButton(container, 'Save');
@@ -80,13 +108,20 @@ describe('Step CSRF Component', () => {
 
 	it('should enable Save and Skip after successful test', async () => {
 		const user = userEvent.setup();
-		vi.mocked(apiClient.withErrorHandling).mockResolvedValue({
+
+		// First call from effect (unlocked), second from test button (success)
+		mockGetCsrfOriginUnlocked();
+		vi.mocked(apiClient.withErrorHandling).mockResolvedValueOnce({
 			data: { success: true, message: 'Origin matches', request_origin: 'http://localhost:3000' },
 			error: undefined
 		});
 
 		const { container } = render(StepCsrf, {
 			props: { onComplete: vi.fn(), onSkip: vi.fn() }
+		});
+
+		await waitFor(() => {
+			expect(findButton(container, 'Test Origin')).toBeTruthy();
 		});
 
 		const testBtn = findButton(container, 'Test Origin')!;
@@ -100,7 +135,9 @@ describe('Step CSRF Component', () => {
 
 	it('should display success result after test', async () => {
 		const user = userEvent.setup();
-		vi.mocked(apiClient.withErrorHandling).mockResolvedValue({
+
+		mockGetCsrfOriginUnlocked();
+		vi.mocked(apiClient.withErrorHandling).mockResolvedValueOnce({
 			data: {
 				success: true,
 				message: 'Origin matches — CSRF protection will work correctly.',
@@ -113,6 +150,10 @@ describe('Step CSRF Component', () => {
 			props: { onComplete: vi.fn(), onSkip: vi.fn() }
 		});
 
+		await waitFor(() => {
+			expect(findButton(container, 'Test Origin')).toBeTruthy();
+		});
+
 		await user.click(findButton(container, 'Test Origin')!);
 
 		expect(container.textContent).toContain('Origin matches');
@@ -122,7 +163,9 @@ describe('Step CSRF Component', () => {
 
 	it('should display failure result after test', async () => {
 		const user = userEvent.setup();
-		vi.mocked(apiClient.withErrorHandling).mockResolvedValue({
+
+		mockGetCsrfOriginUnlocked();
+		vi.mocked(apiClient.withErrorHandling).mockResolvedValueOnce({
 			data: {
 				success: false,
 				message:
@@ -136,6 +179,10 @@ describe('Step CSRF Component', () => {
 			props: { onComplete: vi.fn(), onSkip: vi.fn() }
 		});
 
+		await waitFor(() => {
+			expect(findButton(container, 'Test Origin')).toBeTruthy();
+		});
+
 		await user.click(findButton(container, 'Test Origin')!);
 
 		expect(container.textContent).toContain('Origin mismatch');
@@ -145,6 +192,8 @@ describe('Step CSRF Component', () => {
 
 	it('should reset test state when origin changes', async () => {
 		const user = userEvent.setup();
+
+		mockGetCsrfOriginUnlocked();
 		vi.mocked(apiClient.withErrorHandling).mockResolvedValue({
 			data: { success: true, message: 'Origin matches', request_origin: 'http://localhost:3000' },
 			error: undefined
@@ -152,6 +201,10 @@ describe('Step CSRF Component', () => {
 
 		const { container } = render(StepCsrf, {
 			props: { onComplete: vi.fn(), onSkip: vi.fn() }
+		});
+
+		await waitFor(() => {
+			expect(findButton(container, 'Test Origin')).toBeTruthy();
 		});
 
 		// Run test first
@@ -171,7 +224,8 @@ describe('Step CSRF Component', () => {
 		const onComplete = vi.fn();
 		const user = userEvent.setup();
 
-		// First call: test origin, second call: save
+		// Effect call (unlocked), test origin call, save call
+		mockGetCsrfOriginUnlocked();
 		vi.mocked(apiClient.withErrorHandling)
 			.mockResolvedValueOnce({
 				data: { success: true, message: 'Origin matches', request_origin: 'http://localhost:3000' },
@@ -186,12 +240,17 @@ describe('Step CSRF Component', () => {
 			props: { onComplete, onSkip: vi.fn() }
 		});
 
+		await waitFor(() => {
+			expect(findButton(container, 'Test Origin')).toBeTruthy();
+		});
+
 		// Test first
 		await user.click(findButton(container, 'Test Origin')!);
 		// Then save (test passed, so no confirmation dialog)
 		await user.click(findButton(container, 'Save')!);
 
-		expect(apiClient.withErrorHandling).toHaveBeenCalledTimes(2);
+		// 3 calls: effect's getCsrfOrigin, testCsrfOrigin, setCsrfOrigin
+		expect(apiClient.withErrorHandling).toHaveBeenCalledTimes(3);
 		expect(onComplete).toHaveBeenCalledTimes(1);
 	});
 
@@ -199,6 +258,7 @@ describe('Step CSRF Component', () => {
 		const onSkip = vi.fn();
 		const user = userEvent.setup();
 
+		mockGetCsrfOriginUnlocked();
 		vi.mocked(apiClient.withErrorHandling).mockResolvedValueOnce({
 			data: { success: true, message: 'Origin matches', request_origin: 'http://localhost:3000' },
 			error: undefined
@@ -206,6 +266,10 @@ describe('Step CSRF Component', () => {
 
 		const { container } = render(StepCsrf, {
 			props: { onComplete: vi.fn(), onSkip }
+		});
+
+		await waitFor(() => {
+			expect(findButton(container, 'Test Origin')).toBeTruthy();
 		});
 
 		await user.click(findButton(container, 'Test Origin')!);
@@ -217,6 +281,7 @@ describe('Step CSRF Component', () => {
 	it('should show validation error for empty origin on save', async () => {
 		const user = userEvent.setup();
 
+		mockGetCsrfOriginUnlocked();
 		// Mock test as failed so save triggers confirmation
 		vi.mocked(apiClient.withErrorHandling).mockResolvedValueOnce({
 			data: { success: false, message: 'Failed', request_origin: null },
@@ -225,6 +290,10 @@ describe('Step CSRF Component', () => {
 
 		const { container } = render(StepCsrf, {
 			props: { onComplete: vi.fn(), onSkip: vi.fn() }
+		});
+
+		await waitFor(() => {
+			expect(findButton(container, 'Test Origin')).toBeTruthy();
 		});
 
 		// Clear the auto-populated input
@@ -238,10 +307,7 @@ describe('Step CSRF Component', () => {
 		// Clear input again
 		await user.clear(input);
 
-		// Need a new test since input changed; but buttons are disabled now
-		// Test the validation path: type valid origin, test, then try save with empty
-		// Reset: type origin, test, clear, test again with empty won't work since canTest is false
-		// So let's test validation on save with a path-containing origin
+		// Test the validation path: type a path-containing origin
 		await user.type(input, 'https://example.com/path');
 
 		// Test to enable buttons
@@ -275,7 +341,15 @@ describe('Step CSRF Component', () => {
 		let callCount = 0;
 		vi.mocked(apiClient.withErrorHandling).mockImplementation(async () => {
 			callCount++;
+			// First call: effect's getCsrfOrigin
 			if (callCount === 1) {
+				return {
+					data: { csrf_origin: 'http://localhost:3000', is_locked: false },
+					error: undefined
+				};
+			}
+			// Second call: test origin succeeds
+			if (callCount === 2) {
 				return {
 					data: {
 						success: true,
@@ -285,6 +359,7 @@ describe('Step CSRF Component', () => {
 					error: undefined
 				};
 			}
+			// Third call: save fails
 			return {
 				data: undefined,
 				error: { detail: 'Server unavailable', error_code: 'INTERNAL_ERROR' }
@@ -293,6 +368,10 @@ describe('Step CSRF Component', () => {
 
 		const { container } = render(StepCsrf, {
 			props: { onComplete: vi.fn(), onSkip: vi.fn() }
+		});
+
+		await waitFor(() => {
+			expect(findButton(container, 'Test Origin')).toBeTruthy();
 		});
 
 		await user.click(findButton(container, 'Test Origin')!);
@@ -309,5 +388,69 @@ describe('Step CSRF Component', () => {
 		expect(container.textContent).toContain(
 			'CSRF protection prevents unauthorized requests from other websites'
 		);
+	});
+
+	describe('Locked CSRF (env-managed)', () => {
+		it('should show env badge and a single Continue button when CSRF_ORIGIN is locked', async () => {
+			const onComplete = vi.fn();
+			const onSkip = vi.fn();
+
+			vi.mocked(apiClient.withErrorHandling).mockReset();
+			vi.mocked(apiClient.withErrorHandling).mockResolvedValueOnce({
+				data: { csrf_origin: 'http://localhost:5173', is_locked: true },
+				error: undefined
+			});
+
+			const { container } = render(StepCsrf, {
+				props: { onComplete, onSkip }
+			});
+
+			// Wait for the $effect to settle and the locked-state UI to appear.
+			await waitFor(() => {
+				expect(container.textContent).toContain('Environment Variable');
+			});
+
+			// Save & Continue should NOT be present in locked state
+			expect(findButton(container, 'Save')).toBeUndefined();
+			// Test Origin should be hidden in locked state
+			expect(findButton(container, 'Test Origin')).toBeUndefined();
+			// Skip button should be hidden — replaced by Continue
+			expect(findButton(container, 'Skip')).toBeUndefined();
+
+			// Continue button is present
+			const continueBtn = findButton(container, 'Continue');
+			expect(continueBtn).toBeTruthy();
+
+			// Input should be disabled in locked state
+			const input = container.querySelector('input[type="url"]') as HTMLInputElement;
+			expect(input.disabled).toBe(true);
+			// And display the env-supplied origin
+			expect(input.value).toBe('http://localhost:5173');
+		});
+
+		it('Continue button calls onSkip exactly once (advances onboarding)', async () => {
+			const onComplete = vi.fn();
+			const onSkip = vi.fn();
+			const user = userEvent.setup();
+
+			vi.mocked(apiClient.withErrorHandling).mockReset();
+			vi.mocked(apiClient.withErrorHandling).mockResolvedValueOnce({
+				data: { csrf_origin: 'http://localhost:5173', is_locked: true },
+				error: undefined
+			});
+
+			const { container } = render(StepCsrf, {
+				props: { onComplete, onSkip }
+			});
+
+			await waitFor(() => {
+				expect(findButton(container, 'Continue')).toBeTruthy();
+			});
+
+			await user.click(findButton(container, 'Continue')!);
+
+			expect(onSkip).toHaveBeenCalledTimes(1);
+			expect(onComplete).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/frontend/src/routes/(admin)/+layout.svelte
+++ b/frontend/src/routes/(admin)/+layout.svelte
@@ -198,7 +198,7 @@ $effect(() => {
 		</aside>
 
 		<!-- Main Content Area -->
-		<div class="flex-1 md:ml-64">
+		<div class="flex-1 min-w-0 md:ml-64">
 			<!-- Desktop Header -->
 			<header class="sticky top-0 z-30 hidden h-14 items-center justify-between border-b border-cr-border bg-cr-bg px-6 md:flex">
 				<PageTitle>{currentTitle}</PageTitle>

--- a/frontend/src/routes/(admin)/invitations/[id]/+page.svelte
+++ b/frontend/src/routes/(admin)/invitations/[id]/+page.svelte
@@ -188,7 +188,7 @@ const statusLabel = $derived.by(() => {
 	if (!inv) return "Unknown";
 	if (!inv.enabled) return "Disabled";
 	if (isUsedUp) return "Used up";
-	if (!inv.is_active) return "Inactive";
+	if (!inv.is_active) return "Expired";
 	if (
 		inv.remaining_uses !== null &&
 		inv.remaining_uses !== undefined &&

--- a/frontend/src/routes/(admin)/invitations/[id]/+page.svelte
+++ b/frontend/src/routes/(admin)/invitations/[id]/+page.svelte
@@ -154,15 +154,35 @@ $effect(() => {
 	expiresAtLocal = initialExpiresAtLocal;
 });
 
+// "Used up" beats the generic "Expired" so admins see the specific reason
+// redemption is blocked.
+const isUsedUp = $derived(
+	data.invitation != null &&
+		data.invitation.max_uses != null &&
+		data.invitation.remaining_uses != null &&
+		data.invitation.remaining_uses <= 0,
+);
+
+const isDateExpired = $derived(
+	data.invitation != null &&
+		data.invitation.expires_at != null &&
+		new Date(data.invitation.expires_at).getTime() < Date.now(),
+);
+
 // Derive status for badge
 const status = $derived.by((): StatusBadgeStatus => {
 	const inv = data.invitation;
 	if (!inv) return "disabled";
 	if (!inv.enabled) return "disabled";
+	if (isUsedUp) return "expired";
+	if (isDateExpired) return "expired";
 	if (!inv.is_active) return "expired";
-	if (inv.remaining_uses !== null && inv.remaining_uses !== undefined) {
-		if (inv.remaining_uses <= 0) return "expired";
-		if (inv.remaining_uses <= 3) return "limited";
+	if (
+		inv.remaining_uses !== null &&
+		inv.remaining_uses !== undefined &&
+		inv.remaining_uses <= 3
+	) {
+		return "limited";
 	}
 	return "active";
 });
@@ -172,10 +192,15 @@ const statusLabel = $derived.by(() => {
 	const inv = data.invitation;
 	if (!inv) return "Unknown";
 	if (!inv.enabled) return "Disabled";
-	if (!inv.is_active) return "Expired";
-	if (inv.remaining_uses !== null && inv.remaining_uses !== undefined) {
-		if (inv.remaining_uses <= 0) return "Exhausted";
-		if (inv.remaining_uses <= 3) return "Limited";
+	if (isUsedUp) return "Used up";
+	if (isDateExpired) return "Expired";
+	if (!inv.is_active) return "Inactive";
+	if (
+		inv.remaining_uses !== null &&
+		inv.remaining_uses !== undefined &&
+		inv.remaining_uses <= 3
+	) {
+		return "Limited";
 	}
 	return "Active";
 });

--- a/frontend/src/routes/(admin)/invitations/[id]/+page.svelte
+++ b/frontend/src/routes/(admin)/invitations/[id]/+page.svelte
@@ -163,19 +163,14 @@ const isUsedUp = $derived(
 		data.invitation.remaining_uses <= 0,
 );
 
-const isDateExpired = $derived(
-	data.invitation != null &&
-		data.invitation.expires_at != null &&
-		new Date(data.invitation.expires_at).getTime() < Date.now(),
-);
-
-// Derive status for badge
+// Derive status for badge.
+// Date-expiry is delegated to the server via `is_active` to avoid
+// client-clock-skew false positives.
 const status = $derived.by((): StatusBadgeStatus => {
 	const inv = data.invitation;
 	if (!inv) return "disabled";
 	if (!inv.enabled) return "disabled";
 	if (isUsedUp) return "expired";
-	if (isDateExpired) return "expired";
 	if (!inv.is_active) return "expired";
 	if (
 		inv.remaining_uses !== null &&
@@ -193,7 +188,6 @@ const statusLabel = $derived.by(() => {
 	if (!inv) return "Unknown";
 	if (!inv.enabled) return "Disabled";
 	if (isUsedUp) return "Used up";
-	if (isDateExpired) return "Expired";
 	if (!inv.is_active) return "Inactive";
 	if (
 		inv.remaining_uses !== null &&


### PR DESCRIPTION
## Summary

This PR resolves the five issues surfaced by the latest end-to-end dogfood run (`dogfood-output/report.md`): one critical, three medium, one low. None were runtime crashes; all were correctness or UX gaps spread across the stack. Each fix mirrors patterns already present in the codebase, no new abstractions are introduced, and no database migration is required.

## Issues fixed

### ISSUE-001 — Setup wizard "Save & Continue" silently fails when CSRF_ORIGIN is env-managed (critical, frontend)

`frontend/src/lib/components/setup/step-csrf.svelte`

The wizard step rendered a Save & Continue button regardless of whether the CSRF origin was locked by the `CSRF_ORIGIN` environment variable. The save attempt then failed at the `PUT /api/v1/settings/csrf-origin` call with a confusing error after the test had already reported success.

The step now calls `getCsrfOrigin()` on mount through the existing `withErrorHandling` wrapper, derives an `isLocked` state, and gates the form on it (mirroring the pattern already used in `general-tab.svelte`). When locked, the input is disabled, an `Environment Variable` badge appears next to the card title, the test/save controls are hidden, and a single primary Continue button advances onboarding via the wizard's existing `onSkip` handler (which calls `POST /api/auth/onboarding/advance`). A small loading shimmer covers the brief window before the lock state is known.

### ISSUE-002 — Plex OAuth-supplied email never reaches `Identity.email` (medium, backend)

`backend/src/zondarr/services/oauth_session.py`, `backend/src/zondarr/api/join.py`, `backend/src/zondarr/api/auth.py`, `backend/src/zondarr/api/schemas.py`

The Plex OAuth flow already stores the email returned by `https://plex.tv/api/v2/user` on `OAuthSessionModel.email`, but `OAuthSessionStore.redeem` returned only `(provider, auth_token)`, dropping the email. `JoinController.redeem_invitation` then fell back to `data.email` (empty in the OAuth path) and `Identity.email` ended up `NULL`.

Changes:

- `OAuthSessionStore.redeem` now returns `tuple[str, str, str | None] | None` — `(provider, auth_token, email)`. The `RETURNING` clause adds `OAuthSessionModel.email`. Email is intentionally preserved in storage after redemption so operators can audit who consumed which invitation; only `auth_token` is cleared.
- `JoinController.redeem_invitation` extracts the email and forwards `email=data.email or oauth_email` so a user-typed email still wins, but the OAuth-supplied value is used when the form is empty.
- `UserResponse` gains a `email: str | None` field so the basic list endpoint exposes it. The redemption response populates it from `user.identity.email`. `User.identity` is already `lazy="joined"`, so no query change is needed.
- The two `OAuthSessionStore.redeem` call sites in `api/auth.py` (login + link-provider flows) are updated to the new tuple shape.

### ISSUE-003 — Dashboard horizontally overflows at 390px (medium, frontend)

`frontend/src/routes/(admin)/+layout.svelte`, `frontend/src/lib/components/dashboard/stat-card.svelte`

The main content `<div class="flex-1 md:ml-64">` and the stat-card `<div class="flex items-start justify-between">` were flex items with default `min-width: auto`, preventing them from shrinking below their intrinsic content width. At 390px viewport this produced a 44px horizontal scroll.

Added `min-w-0` (and `gap-3` on the stat card) to the affected flex containers, mirroring the existing pattern in `server-card.svelte`, `recent-activity.svelte`, and `log-viewer.svelte`.

### ISSUE-004 — A used-up `max_uses=1` invitation displays "Expired" (medium, frontend)

`frontend/src/lib/components/invitations/invitation-row.svelte`, `frontend/src/routes/(admin)/invitations/[id]/+page.svelte`

The `$derived.by` blocks short-circuited on `is_active=false` and returned `Expired` before the `remaining_uses<=0` branch could run, so the existing `Exhausted` label was dead code. Both the row component and the detail page now compute `isUsedUp` and `isDateExpired` as separate derived values, then evaluate `isUsedUp` first to label such invitations as `Used up`. The redundant `is_active=false` branch is retained as `Inactive` for any future backend-side reason. The visual styling (rose) remains shared since both states are non-redeemable.

The `Used up` wording matches the public-page message ("This invitation has reached its maximum number of uses.") and is more legible than "Exhausted" for non-technical admins.

### ISSUE-005 — HTTP-request logs render `content_type=('', {})` (low, backend)

`backend/src/zondarr/core/log_buffer.py`, `backend/src/zondarr/app.py`

Litestar's `LoggingMiddleware` binds `request.content_type` to the structlog event dict. `Request.content_type` is a `tuple[str, dict[str, str]]` (mimetype, params), and the buffer's `capture_log_processor` stringifies every field via `str(value)`, so the tuple's repr ended up in the log line.

Added `normalize_content_type_processor` in `core/log_buffer.py` that flattens any `tuple` value of `content_type` to its mimetype string. It is inserted into the structlog processor chain in `app.py` immediately before `capture_log_processor`, so the buffer captures the cleaned value.

## Tests

- `backend/tests/test_oauth_session.py` — extended `TestOneTimeRedemption` to cover the new email tuple position, the `None` email case, and the post-redemption email preservation guarantee.
- `backend/tests/test_log_buffer_processors.py` — new file covering the populated tuple, empty tuple, plain string, missing key, non-string first element, and field preservation cases.
- `frontend/src/lib/components/setup/step-csrf.svelte.test.ts` — updated existing tests to mock the new `getCsrfOrigin` effect call; added a `Locked CSRF (env-managed)` describe block asserting the badge appears, Save/Test/Skip are hidden, and the Continue button calls `onSkip` exactly once.
- `frontend/src/lib/components/setup/setup-wizard.svelte.test.ts` — updated the CSRF flow mock chain to include the leading `getCsrfOrigin` call.
- `frontend/src/lib/components/dashboard/stat-card.svelte.test.ts` (and `stat-card-test-harness.svelte`) — new file asserting the rendered DOM has `min-w-0` and `gap-3` on the inner flex row and `min-w-0` on the title/value text wrapper.
- `frontend/src/lib/components/invitations/invitation-row.svelte.test.ts` — new file covering disabled, used-up, date-expired, healthy, limited, and unlimited invitation states.

## Verification

- Backend: `uv run ruff check .` clean, `uv run basedpyright` 0 errors / 0 warnings, `uv run pytest` all 764 tests pass.
- Frontend: `bun run check` (svelte-check) 0 errors / 0 warnings, `bun run test` (vitest) all 312 tests pass, `biome check` clean for the modified files.
- No migration required (no new columns; the email column already exists on `oauth_sessions` and `identities`).

## Test plan

- [ ] Setup wizard SECURITY step at `/setup` with `CSRF_ORIGIN` set in the environment shows the Environment Variable badge and a single Continue button; clicking it advances to the Server step.
- [ ] Setup wizard SECURITY step without `CSRF_ORIGIN` continues to show the original Test / Save & Continue / Skip flow.
- [ ] Plex OAuth redemption: `GET /api/v1/users/<id>` and `GET /api/v1/users` both expose `email` from the OAuth-supplied value when the join form leaves email blank.
- [ ] Responsive sweep at 390x844: `document.querySelector('main').getBoundingClientRect().width` equals `documentElement.clientWidth` on `/dashboard`, `/invitations`, and `/servers/<id>`.
- [ ] Invitations list with a fully-redeemed `max_uses=1` invitation (future `expires_at`) reads `Used up`; an invitation with a past `expires_at` reads `Expired`.
- [ ] `/logs` panel: every HTTP Request line shows `content_type=` followed by a plain string (`application/json`, `""`, etc.) and never `('', {})`.