### PR TITLE
Fix dogfood findings

### DIFF
--- a/backend/src/zondarr/api/schemas.py
+++ b/backend/src/zondarr/api/schemas.py
@@ -141,14 +141,14 @@ class MediaServerCreate(msgspec.Struct, kw_only=True, forbid_unknown_fields=True
     Attributes:
         name: Human-readable name for the server.
         server_type: Type of media server (e.g., "plex", "jellyfin").
-        url: Base URL for the media server API.
+        url: Base URL for the media server API. Optional if use_env_credentials is True.
         api_key: Authentication token for the media server (optional if use_env_credentials is True).
-        use_env_credentials: If True, resolve api_key from environment variables on the server.
+        use_env_credentials: If True, resolve URL and api_key from environment variables on the server.
     """
 
     name: NonEmptyStr
     server_type: NonEmptyStr
-    url: UrlStr
+    url: UrlStr | None = None
     api_key: ApiKeyStr | None = None
     use_env_credentials: bool = False
 
@@ -163,16 +163,12 @@ class EnvCredentialResponse(msgspec.Struct, kw_only=True):
     Attributes:
         server_type: Provider identifier string (e.g., "plex", "jellyfin").
         display_name: Human-readable provider name.
-        url: Detected URL from env var (for form auto-fill).
-        masked_api_key: Masked version of the API key for display.
         has_url: Whether a URL was detected.
         has_api_key: Whether an API key was detected.
     """
 
     server_type: str
     display_name: str
-    url: str | None = None
-    masked_api_key: str | None = None
     has_url: bool = False
     has_api_key: bool = False
 
@@ -988,6 +984,8 @@ class UserDetailResponse(msgspec.Struct, omit_defaults=True):
         media_server_id: ID of the media server.
         external_user_id: The user's ID on the media server.
         username: The username on the media server.
+        email: Email captured for the parent identity (OAuth-supplied,
+            user-entered, or provider-supplied), or None if unknown.
         enabled: Whether the user account is currently active.
         created_at: When the user was created.
         identity: The parent identity with all linked users.
@@ -1007,6 +1005,7 @@ class UserDetailResponse(msgspec.Struct, omit_defaults=True):
     created_at: datetime
     identity: IdentityResponse
     media_server: MediaServerResponse
+    email: str | None = None
     external_user_type: str | None = None
     expires_at: datetime | None = None
     updated_at: datetime | None = None
@@ -1337,13 +1336,13 @@ class ConnectionTestRequest(msgspec.Struct, kw_only=True, forbid_unknown_fields=
     by probing all registered providers concurrently.
 
     Attributes:
-        url: Base URL for the media server API.
+        url: Base URL for the media server API. Optional if use_env_credentials is True.
         api_key: Authentication token for the media server (optional if use_env_credentials is True).
         server_type: Optional type of media server. Auto-detected if omitted.
-        use_env_credentials: If True, resolve api_key from environment variables on the server.
+        use_env_credentials: If True, resolve URL and api_key from environment variables on the server.
     """
 
-    url: UrlStr
+    url: UrlStr | None = None
     api_key: ApiKeyStr | None = None
     server_type: NonEmptyStr | None = None
     use_env_credentials: bool = False

--- a/backend/src/zondarr/api/servers.py
+++ b/backend/src/zondarr/api/servers.py
@@ -236,6 +236,40 @@ class ServerController(Controller):
         return api_key
 
     @staticmethod
+    def _resolve_url(
+        url: str | None,
+        use_env_credentials: bool,
+        server_type: str | None,
+        settings: Settings,
+    ) -> str:
+        """Resolve media server URL from request body or environment credentials."""
+        if use_env_credentials:
+            if server_type is None:
+                raise ValidationError(
+                    "server_type is required when using environment credentials",
+                    field_errors={
+                        "server_type": ["Required when use_env_credentials is true"]
+                    },
+                )
+            provider_creds = settings.provider_credentials.get(server_type, {})
+            env_url = provider_creds.get("url")
+            if not env_url:
+                raise ValidationError(
+                    f"No URL found in environment for provider '{server_type}'",
+                    field_errors={
+                        "url": [f"No environment URL configured for {server_type}"]
+                    },
+                )
+            return env_url
+
+        if not url:
+            raise ValidationError(
+                "URL is required",
+                field_errors={"url": ["URL is required"]},
+            )
+        return url
+
+    @staticmethod
     def _to_library_response(
         library_id: UUID,
         name: str,
@@ -416,8 +450,6 @@ class ServerController(Controller):
                 EnvCredentialResponse(
                     server_type=meta.server_type,
                     display_name=meta.display_name,
-                    url=url,
-                    masked_api_key=mask_api_key(api_key) if api_key else None,
                     has_url=bool(url),
                     has_api_key=bool(api_key),
                 )
@@ -557,6 +589,9 @@ class ServerController(Controller):
             ValidationError: If connection validation fails.
         """
         # Resolve API key: from env credentials or from the request body
+        url = self._resolve_url(
+            data.url, data.use_env_credentials, data.server_type, settings
+        )
         api_key = self._resolve_api_key(
             data.api_key, data.use_env_credentials, data.server_type, settings
         )
@@ -564,7 +599,7 @@ class ServerController(Controller):
         server = await media_server_service.add(
             name=data.name,
             server_type=data.server_type,
-            url=data.url,
+            url=url,
             api_key=api_key,
         )
 
@@ -788,6 +823,9 @@ class ServerController(Controller):
         """
         # Resolve API key: from env credentials or from the request body
         try:
+            url = self._resolve_url(
+                data.url, data.use_env_credentials, data.server_type, settings
+            )
             api_key = self._resolve_api_key(
                 data.api_key, data.use_env_credentials, data.server_type, settings
             )
@@ -799,7 +837,7 @@ class ServerController(Controller):
 
         try:
             success, detected_type, info = await media_server_service.detect_and_test(
-                url=data.url,
+                url=url,
                 api_key=api_key,
                 server_type=data.server_type,
             )

--- a/backend/src/zondarr/api/users.py
+++ b/backend/src/zondarr/api/users.py
@@ -165,8 +165,8 @@ class UserController(Controller):
         """List users with pagination.
 
         Supports filtering by media_server_id, invitation_id, enabled status,
-        and expiration status. Supports sorting by created_at, username, and
-        expires_at. Enforces page_size max of 100.
+        expiration status, and broad search. Supports sorting by created_at,
+        username, and expires_at. Enforces page_size max of 100.
 
         Args:
             user_service: UserService from DI.
@@ -176,6 +176,8 @@ class UserController(Controller):
             invitation_id: Filter by invitation ID.
             enabled: Filter by enabled status.
             expired: Filter by expiration status.
+            search: Broad case-insensitive search across users, identities,
+                servers, and invitation codes.
             sort_by: Field to sort by.
             sort_order: Sort direction.
 

--- a/backend/src/zondarr/api/users.py
+++ b/backend/src/zondarr/api/users.py
@@ -145,6 +145,12 @@ class UserController(Controller):
             bool | None,
             Parameter(description="Filter by expiration status"),
         ] = None,
+        search: Annotated[
+            str | None,
+            Parameter(
+                description="Broad case-insensitive search across users, identities, servers, and invitation codes",
+            ),
+        ] = None,
         sort_by: Annotated[
             str,
             Parameter(
@@ -197,6 +203,7 @@ class UserController(Controller):
             invitation_id=invitation_id,
             enabled=enabled,
             expired=expired,
+            search=search,
             sort_by=sort_by,  # pyright: ignore[reportArgumentType]
             sort_order=sort_order,  # pyright: ignore[reportArgumentType]
         )
@@ -444,7 +451,8 @@ class UserController(Controller):
         """
         await user_service.delete(user_id, force=force)
 
-    def _to_detail_response(self, user: User, /) -> UserDetailResponse:
+    @staticmethod
+    def _to_detail_response(user: User, /) -> UserDetailResponse:
         """Convert a User entity to UserDetailResponse.
 
         Args:
@@ -523,6 +531,7 @@ class UserController(Controller):
             created_at=user.created_at,
             identity=identity_response,
             media_server=media_server_response,
+            email=user.identity.email,
             external_user_type=user.external_user_type,
             expires_at=user.expires_at,
             updated_at=user.updated_at,

--- a/backend/src/zondarr/repositories/user.py
+++ b/backend/src/zondarr/repositories/user.py
@@ -10,12 +10,14 @@ from datetime import UTC, datetime
 from typing import Literal, override
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql import Select
 
 from zondarr.core.exceptions import RepositoryError
-from zondarr.models.identity import User
+from zondarr.models.identity import Identity, User
+from zondarr.models.invitation import Invitation
+from zondarr.models.media_server import MediaServer
 from zondarr.repositories.base import Repository
 
 # Type alias for valid sort fields
@@ -193,6 +195,7 @@ class UserRepository(Repository[User]):
         invitation_id: UUID | None = None,
         enabled: bool | None = None,
         expired: bool | None = None,
+        search: str | None = None,
         sort_by: UserSortField = "created_at",
         sort_order: SortOrder = "desc",
     ) -> tuple[Sequence[User], int]:
@@ -210,6 +213,7 @@ class UserRepository(Repository[User]):
             enabled: Filter by enabled status. None means no filter.
             expired: Filter by expiration status. None means no filter.
                 True = only expired, False = only non-expired.
+            search: Broad case-insensitive contains search. None means no filter.
             sort_by: Field to sort by. One of: created_at, username, expires_at.
             sort_order: Sort direction. One of: asc, desc.
 
@@ -227,6 +231,7 @@ class UserRepository(Repository[User]):
                 invitation_id=invitation_id,
                 enabled=enabled,
                 expired=expired,
+                search=search,
             )
 
             # Get total count
@@ -270,6 +275,7 @@ class UserRepository(Repository[User]):
         invitation_id: UUID | None = None,
         enabled: bool | None = None,
         expired: bool | None = None,
+        search: str | None = None,
     ) -> Select[tuple[User]]:
         """Build a filtered query for users.
 
@@ -278,6 +284,7 @@ class UserRepository(Repository[User]):
             invitation_id: Filter by invitation ID. None means no filter.
             enabled: Filter by enabled status. None means no filter.
             expired: Filter by expiration status. None means no filter.
+            search: Broad case-insensitive contains search. None means no filter.
 
         Returns:
             A SQLAlchemy Select statement with filters applied.
@@ -310,6 +317,26 @@ class UserRepository(Repository[User]):
                 query = query.where(
                     (User.expires_at == None) | (User.expires_at > now)  # noqa: E711
                 )
+
+        search_term = search.strip() if search is not None else ""
+        if search_term:
+            pattern = f"%{search_term}%"
+            query = (
+                query.join(User.identity)
+                .join(User.media_server)
+                .outerjoin(User.invitation)
+                .where(
+                    or_(
+                        User.username.ilike(pattern),
+                        User.external_user_id.ilike(pattern),
+                        Identity.display_name.ilike(pattern),
+                        Identity.email.ilike(pattern),
+                        MediaServer.name.ilike(pattern),
+                        MediaServer.server_type.ilike(pattern),
+                        Invitation.code.ilike(pattern),
+                    )
+                )
+            )
 
         return query
 

--- a/backend/src/zondarr/services/redemption.py
+++ b/backend/src/zondarr/services/redemption.py
@@ -312,10 +312,12 @@ class RedemptionService:
                     cleaned_count=cleaned,
                 )
 
+            identity_email = email or self._first_external_email(created_external_users)
+
             # Step 5: Create local Identity and User records
             identity, users = await self.user_service.create_identity_with_users(
                 display_name=username,
-                email=email,
+                email=identity_email,
                 expires_at=expires_at,
                 external_users=created_external_users,
                 invitation_id=invitation.id,
@@ -393,6 +395,17 @@ class RedemptionService:
             _background_tasks.add(task)
 
         return identity, users
+
+    @staticmethod
+    def _first_external_email(
+        external_users: Sequence[tuple[MediaServer, ExternalUser]],
+        /,
+    ) -> str | None:
+        """Return the first provider-reported email from created users."""
+        for _, external_user in external_users:
+            if external_user.email:
+                return external_user.email
+        return None
 
     @staticmethod
     async def _create_user_with_retry(

--- a/backend/src/zondarr/services/sync.py
+++ b/backend/src/zondarr/services/sync.py
@@ -127,7 +127,7 @@ class SyncService:
         matched_ids = external_ids & local_ids
         matched_count = len(matched_ids)
 
-        # Update external_user_type for matched users whose type is missing or changed
+        # Update matched local records with provider metadata that was previously missing.
         if matched_ids and not dry_run:
             local_user_map = {u.external_user_id: u for u in local_users}
             for ext_id in matched_ids:
@@ -140,6 +140,13 @@ class SyncService:
                 ):
                     local_user.external_user_type = ext_user.user_type
                     _ = await self.user_repo.update(local_user)
+                if (
+                    local_user is not None
+                    and not local_user.identity.email
+                    and ext_user.email
+                ):
+                    local_user.identity.email = ext_user.email
+                    _ = await self.identity_repo.update(local_user.identity)
 
         # Import orphaned users when not a dry run
         imported_count = 0

--- a/backend/src/zondarr/services/user.py
+++ b/backend/src/zondarr/services/user.py
@@ -419,6 +419,7 @@ class UserService:
         invitation_id: UUID | None = None,
         enabled: bool | None = None,
         expired: bool | None = None,
+        search: str | None = None,
         sort_by: UserSortField = "created_at",
         sort_order: SortOrder = "desc",
     ) -> tuple[Sequence[User], int]:
@@ -436,6 +437,7 @@ class UserService:
             enabled: Filter by enabled status. None means no filter (keyword-only).
             expired: Filter by expiration status. None means no filter (keyword-only).
                 True = only expired, False = only non-expired.
+            search: Broad case-insensitive contains search. None means no filter.
             sort_by: Field to sort by. One of: created_at, username, expires_at (keyword-only).
             sort_order: Sort direction. One of: asc, desc (keyword-only).
 
@@ -457,6 +459,7 @@ class UserService:
             invitation_id=invitation_id,
             enabled=enabled,
             expired=expired,
+            search=search,
             sort_by=sort_by,
             sort_order=sort_order,
         )

--- a/backend/tests/test_env_credentials.py
+++ b/backend/tests/test_env_credentials.py
@@ -20,6 +20,7 @@ from zondarr.api.servers import (
     mask_api_key,
 )
 from zondarr.config import Settings
+from zondarr.core.exceptions import ValidationError
 from zondarr.media.providers.jellyfin import JellyfinProvider
 from zondarr.media.providers.plex import PlexProvider
 from zondarr.media.registry import registry
@@ -181,8 +182,9 @@ class TestEnvCredentialsEndpoint:
                     (c for c in creds if c["server_type"] == "plex"), None
                 )
                 assert plex_cred is not None
-                assert plex_cred["url"] == "http://plex.local:32400"
+                assert "url" not in plex_cred
                 assert "api_key" not in plex_cred
+                assert "masked_api_key" not in plex_cred
                 assert plex_cred["has_url"] is True
                 assert plex_cred["has_api_key"] is True
                 assert plex_cred["display_name"] == "Plex"
@@ -215,8 +217,8 @@ class TestEnvCredentialsEndpoint:
             await engine.dispose()
 
     @pytest.mark.asyncio
-    async def test_masked_key_format(self) -> None:
-        """Masked API key is properly formatted."""
+    async def test_env_credential_response_does_not_expose_url_or_token(self) -> None:
+        """Environment credential response only exposes availability metadata."""
         engine = await create_test_engine()
         try:
             session_factory = async_sessionmaker(engine, expire_on_commit=False)
@@ -238,8 +240,12 @@ class TestEnvCredentialsEndpoint:
                 plex_cred: CredentialDict = next(
                     c for c in creds if c["server_type"] == "plex"
                 )
-                # 16 char key: first 4 + 8 stars + last 4
-                assert plex_cred["masked_api_key"] == "abcd********mnop"
+                assert plex_cred == {
+                    "server_type": "plex",
+                    "display_name": "Plex",
+                    "has_url": True,
+                    "has_api_key": True,
+                }
         finally:
             await engine.dispose()
 
@@ -267,6 +273,8 @@ class TestEnvCredentialsEndpoint:
                 assert plex_cred["has_url"] is True
                 assert plex_cred["has_api_key"] is False
                 assert "api_key" not in plex_cred
+                assert "url" not in plex_cred
+                assert "masked_api_key" not in plex_cred
         finally:
             await engine.dispose()
 
@@ -300,3 +308,32 @@ class TestEnvCredentialsEndpoint:
                 assert "jellyfin" in server_types
         finally:
             await engine.dispose()
+
+    def test_env_backed_resolution_uses_server_side_url_and_api_key(self) -> None:
+        """Env-backed create/test requests can omit URL and API key."""
+        settings = _make_test_settings(
+            provider_credentials={
+                "plex": {
+                    "url": "http://plex.local:32400",
+                    "api_key": "plex-token",
+                },
+            }
+        )
+
+        assert (
+            ServerController._resolve_url(None, True, "plex", settings)  # pyright: ignore[reportPrivateUsage]
+            == "http://plex.local:32400"
+        )
+        assert (
+            ServerController._resolve_api_key(None, True, "plex", settings)  # pyright: ignore[reportPrivateUsage]
+            == "plex-token"
+        )
+
+    def test_env_backed_resolution_requires_configured_url(self) -> None:
+        """Env mode rejects missing provider URL server-side."""
+        settings = _make_test_settings(
+            provider_credentials={"plex": {"api_key": "plex-token"}}
+        )
+
+        with pytest.raises(ValidationError):
+            _ = ServerController._resolve_url(None, True, "plex", settings)  # pyright: ignore[reportPrivateUsage]

--- a/backend/tests/test_redemption_retry.py
+++ b/backend/tests/test_redemption_retry.py
@@ -47,10 +47,15 @@ def _make_invitation(
     return inv
 
 
-def _make_external_user(username: str = "testuser") -> ExternalUser:
+def _make_external_user(
+    username: str = "testuser",
+    *,
+    email: str | None = None,
+) -> ExternalUser:
     return ExternalUser(
         external_user_id=str(uuid4()),
         username=username,
+        email=email,
     )
 
 
@@ -140,6 +145,36 @@ class TestRedemptionRetry:
         assert len(users) == 1
         # Verify 3 client creations (2 failures + 1 success)
         assert call_count == 3
+
+    async def test_redeem_uses_external_user_email_when_request_email_missing(
+        self,
+    ) -> None:
+        """Provider-reported email backfills identity email during redemption."""
+        service, invitation_service, user_service = _make_redemption_service()
+        url = _TEST_URL
+        api_key = _TEST_API_KEY
+        server = _make_server(url=url, api_key=api_key)
+        invitation = _make_invitation(servers=[server])
+        invitation_service.get_by_code = AsyncMock(return_value=invitation)
+
+        external_user = _make_external_user(email="plexuser@example.com")
+        client = _make_client(url=url, api_key=api_key)
+        client.create_user = AsyncMock(return_value=external_user)
+
+        mock_registry = MagicMock()
+        mock_registry.create_client_for_server = MagicMock(return_value=client)
+        mock_registry.get_provider = MagicMock()
+
+        with patch("zondarr.services.redemption.registry", mock_registry):
+            _identity, _users = await service.redeem(
+                "TEST-CODE", username="testuser", password="testpass"
+            )
+
+        user_service.create_identity_with_users.assert_awaited_once()  # pyright: ignore[reportAny]
+        assert (
+            user_service.create_identity_with_users.await_args.kwargs["email"]  # pyright: ignore[reportAny]
+            == "plexuser@example.com"
+        )
 
     async def test_create_user_no_retry_on_username_taken(self) -> None:
         """MediaClientError with USERNAME_TAKEN is NOT retried."""

--- a/backend/tests/test_sync_email_backfill.py
+++ b/backend/tests/test_sync_email_backfill.py
@@ -1,0 +1,127 @@
+"""Tests for sync-time identity email backfill."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from zondarr.media.types import ExternalUser
+from zondarr.models.identity import Identity, User
+from zondarr.models.media_server import MediaServer
+from zondarr.repositories.identity import IdentityRepository
+from zondarr.repositories.media_server import MediaServerRepository
+from zondarr.repositories.user import UserRepository
+from zondarr.services.sync import SyncService
+
+
+@pytest.mark.asyncio
+async def test_sync_backfills_missing_identity_email_for_matched_user(
+    session: AsyncSession,
+) -> None:
+    """Non-dry-run sync stores provider email when the local identity lacks one."""
+    server = MediaServer(
+        name="Plex",
+        server_type="plex",
+        url="http://plex.local",
+        api_key="token",
+        enabled=True,
+    )
+    identity = Identity(display_name="Plex User", email=None, enabled=True)
+    session.add_all([server, identity])
+    await session.flush()
+
+    user = User(
+        identity_id=identity.id,
+        media_server_id=server.id,
+        external_user_id="plex-123",
+        username="plexuser",
+        enabled=True,
+    )
+    session.add(user)
+    await session.flush()
+
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    client.list_users = AsyncMock(
+        return_value=[
+            ExternalUser(
+                external_user_id="plex-123",
+                username="plexuser",
+                email="plexuser@example.com",
+            )
+        ]
+    )
+    mock_registry = MagicMock()
+    mock_registry.create_client_for_server = MagicMock(return_value=client)
+
+    service = SyncService(
+        MediaServerRepository(session),
+        UserRepository(session),
+        IdentityRepository(session),
+    )
+
+    with patch("zondarr.services.sync.registry", mock_registry):
+        result = await service.sync_server(server.id, dry_run=False)
+
+    assert result.matched_users == 1
+    await session.refresh(identity)
+    assert identity.email == "plexuser@example.com"
+
+
+@pytest.mark.asyncio
+async def test_sync_preserves_existing_identity_email_for_matched_user(
+    session: AsyncSession,
+) -> None:
+    """Provider email does not overwrite an existing local identity email."""
+    server = MediaServer(
+        name="Plex",
+        server_type="plex",
+        url="http://plex.local",
+        api_key="token",
+        enabled=True,
+    )
+    identity = Identity(
+        display_name="Plex User",
+        email="local@example.com",
+        enabled=True,
+    )
+    session.add_all([server, identity])
+    await session.flush()
+
+    user = User(
+        identity_id=identity.id,
+        media_server_id=server.id,
+        external_user_id="plex-123",
+        username="plexuser",
+        enabled=True,
+    )
+    session.add(user)
+    await session.flush()
+
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    client.list_users = AsyncMock(
+        return_value=[
+            ExternalUser(
+                external_user_id="plex-123",
+                username="plexuser",
+                email="provider@example.com",
+            )
+        ]
+    )
+    mock_registry = MagicMock()
+    mock_registry.create_client_for_server = MagicMock(return_value=client)
+
+    service = SyncService(
+        MediaServerRepository(session),
+        UserRepository(session),
+        IdentityRepository(session),
+    )
+
+    with patch("zondarr.services.sync.registry", mock_registry):
+        _ = await service.sync_server(server.id, dry_run=False)
+
+    await session.refresh(identity)
+    assert identity.email == "local@example.com"

--- a/backend/tests/test_user_search.py
+++ b/backend/tests/test_user_search.py
@@ -1,0 +1,151 @@
+"""Tests for user list search and email response aliases."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from zondarr.api.users import UserController
+from zondarr.media.providers.plex import PlexProvider
+from zondarr.media.registry import registry
+from zondarr.models.identity import Identity, User
+from zondarr.models.invitation import Invitation
+from zondarr.models.media_server import MediaServer
+from zondarr.repositories.identity import IdentityRepository
+from zondarr.repositories.user import UserRepository
+from zondarr.services.user import UserService
+
+
+async def _make_user(
+    session: AsyncSession,
+    *,
+    username: str,
+    external_user_id: str,
+    identity_name: str,
+    email: str | None,
+    server_name: str,
+    server_type: str = "plex",
+    invitation_code: str | None = None,
+    enabled: bool = True,
+) -> User:
+    server = MediaServer(
+        name=server_name,
+        server_type=server_type,
+        url=f"http://{server_name.lower()}.local",
+        api_key="token",
+        enabled=True,
+    )
+    identity = Identity(display_name=identity_name, email=email, enabled=True)
+    invitation = (
+        Invitation(code=invitation_code, enabled=True) if invitation_code else None
+    )
+    session.add_all([server, identity])
+    if invitation is not None:
+        session.add(invitation)
+    await session.flush()
+
+    user = User(
+        identity_id=identity.id,
+        media_server_id=server.id,
+        invitation_id=invitation.id if invitation is not None else None,
+        external_user_id=external_user_id,
+        username=username,
+        enabled=enabled,
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_list_users_search_matches_supported_fields(
+    session: AsyncSession,
+) -> None:
+    """Broad search matches users, identities, servers, and invitation codes."""
+    user = await _make_user(
+        session,
+        username="plexuser",
+        external_user_id="external-123",
+        identity_name="Plex Person",
+        email="person@example.com",
+        server_name="LivingRoom",
+        invitation_code="WELCOME42",
+    )
+    _ = await _make_user(
+        session,
+        username="otheruser",
+        external_user_id="external-999",
+        identity_name="Other Person",
+        email="other@example.com",
+        server_name="Bedroom",
+        server_type="jellyfin",
+        invitation_code="OTHER42",
+    )
+
+    service = UserService(UserRepository(session), IdentityRepository(session))
+
+    for term in [
+        "PLEXUSER",
+        "external-123",
+        "plex person",
+        "PERSON@EXAMPLE.COM",
+        "livingroom",
+        "plex",
+        "welcome42",
+    ]:
+        items, total = await service.list_users(search=term)
+        assert total == 1
+        assert items[0].id == user.id
+
+
+@pytest.mark.asyncio
+async def test_list_users_search_composes_with_existing_filters(
+    session: AsyncSession,
+) -> None:
+    """Search uses AND semantics with existing filters."""
+    _ = await _make_user(
+        session,
+        username="targetuser",
+        external_user_id="target-1",
+        identity_name="Target Enabled",
+        email="target-enabled@example.com",
+        server_name="Main",
+        enabled=True,
+    )
+    _ = await _make_user(
+        session,
+        username="targetuser2",
+        external_user_id="target-2",
+        identity_name="Target Disabled",
+        email="target-disabled@example.com",
+        server_name="Main",
+        enabled=False,
+    )
+
+    service = UserService(UserRepository(session), IdentityRepository(session))
+
+    items, total = await service.list_users(search="target", enabled=False)
+
+    assert total == 1
+    assert items[0].username == "targetuser2"
+
+
+@pytest.mark.asyncio
+async def test_user_detail_response_exposes_top_level_email(
+    session: AsyncSession,
+) -> None:
+    """UserDetailResponse.email mirrors identity.email."""
+    registry.register(PlexProvider())
+    user = await _make_user(
+        session,
+        username="plexuser",
+        external_user_id="external-123",
+        identity_name="Plex Person",
+        email="person@example.com",
+        server_name="LivingRoom",
+    )
+    service = UserService(UserRepository(session), IdentityRepository(session))
+    loaded_user = await service.get_user_detail(user.id)
+
+    response = UserController._to_detail_response(loaded_user)  # pyright: ignore[reportPrivateUsage]
+
+    assert response.email == "person@example.com"
+    assert response.identity.email == "person@example.com"

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -362,6 +362,7 @@ export interface ListUsersParams {
 	invitation_id?: string;
 	enabled?: boolean;
 	expired?: boolean;
+	search?: string;
 	sort_by?: 'created_at' | 'username' | 'expires_at';
 	sort_order?: 'asc' | 'desc';
 }
@@ -543,7 +544,7 @@ export async function resetCircuitBreaker(
 export interface CreateServerRequest {
 	name: string;
 	server_type: string;
-	url: string;
+	url?: string | null;
 	api_key?: string;
 	use_env_credentials?: boolean;
 }
@@ -585,8 +586,8 @@ export async function getServer(
 
 // Override generated type to support use_env_credentials flow
 export interface ConnectionTestRequest {
-	url: string;
-	api_key?: string;
+	url?: string | null;
+	api_key?: string | null;
 	server_type?: string | null;
 	use_env_credentials?: boolean;
 }
@@ -597,8 +598,6 @@ export type ConnectionTestResponse = components['schemas']['ConnectionTestRespon
 export interface EnvCredentialResponse {
 	server_type: string;
 	display_name: string;
-	url: string | null;
-	masked_api_key: string | null;
 	has_url: boolean;
 	has_api_key: boolean;
 }

--- a/frontend/src/lib/api/types.d.ts
+++ b/frontend/src/lib/api/types.d.ts
@@ -1218,7 +1218,7 @@ export interface components {
 		};
 		/** ConnectionTestRequest */
 		ConnectionTestRequest: {
-			url: string;
+			url?: string | null;
 			api_key?: string | null;
 			server_type?: string | null;
 			/** @default false */
@@ -1287,8 +1287,6 @@ export interface components {
 		EnvCredentialResponse: {
 			server_type: string;
 			display_name: string;
-			url?: string | null;
-			masked_api_key?: string | null;
 			/** @default false */
 			has_url: boolean;
 			/** @default false */
@@ -1301,23 +1299,23 @@ export interface components {
 		/**
 		 * ErrorResponse
 		 * @example {
-		 *       "detail": "dueXWxItGmpndvrqpUKE",
-		 *       "error_code": "voiQUvZgiPQBXBLnzSvg",
-		 *       "timestamp": "2008-07-18T16:12:37.008312",
+		 *       "detail": "FbCGQpmtiObDRbiZpNby",
+		 *       "error_code": "cmaJxsvJnicHImAYyNsC",
+		 *       "timestamp": "2019-09-19T06:44:15.542110",
 		 *       "correlation_id": null
 		 *     }
 		 */
 		ErrorResponse: {
-			/** @example dkahSRhbAKyyyVhuiIKQ */
+			/** @example txqMNuKkXmitSFJQuXZB */
 			detail: string;
-			/** @example jAycEiKZzsXNStUXMqcc */
+			/** @example MSEgIxSkajitkrEizsaJ */
 			error_code: string;
 			/**
 			 * Format: date-time
-			 * @example 2006-05-16T20:15:11.423369
+			 * @example 2011-05-26T14:31:52.249094
 			 */
 			timestamp: string;
-			/** @example gGCCJMLRlAzRIOjdLiFB */
+			/** @example eXNSQubZGLKpIxlzypMV */
 			correlation_id?: string | null;
 		};
 		/** ExpirationIntervalUpdate */
@@ -1462,7 +1460,7 @@ export interface components {
 		MediaServerCreate: {
 			name: string;
 			server_type: string;
-			url: string;
+			url?: string | null;
 			api_key?: string | null;
 			/** @default false */
 			use_env_credentials: boolean;
@@ -1578,22 +1576,21 @@ export interface components {
 		/**
 		 * RedemptionErrorResponse
 		 * @example {
-		 *       "success": true,
-		 *       "error_code": "fLqpHUrVGFBaiJKfHyEu",
-		 *       "message": "lsYjSBdQaRrVLsGZikpQ",
-		 *       "correlation_id": null,
+		 *       "success": false,
+		 *       "error_code": "EodTGDbubHwRjcqyOagX",
+		 *       "message": "kVuCETNggRJNjKdIMjvc",
+		 *       "correlation_id": "iKExjuxXLIhneaoVqNBo",
 		 *       "failed_server": null,
 		 *       "partial_users": [
 		 *         {
-		 *           "id": "62e6750a-3f13-491d-a7fc-c18b3f36d149",
-		 *           "identity_id": "9875bad1-95a6-4ea9-8b87-3e099d5d310b",
-		 *           "media_server_id": "c2cc1d38-8d15-4800-9fad-ea816b327c79",
-		 *           "external_user_id": "babcOYguawIGUCctxrbG",
-		 *           "username": "zKsdnjxheBhfgKPQDHNw",
+		 *           "id": "cf4c7d08-55aa-48ab-8e80-f7b19e49c4a1",
+		 *           "identity_id": "a29ceee2-4279-4939-9367-283200e5d88f",
+		 *           "media_server_id": "6d7aa72a-8479-4779-80f1-be0beee230a7",
+		 *           "external_user_id": "ThdcdkahSRhbAKyyyVhu",
+		 *           "username": "iIKQjAycEiKZzsXNStUX",
 		 *           "enabled": false,
-		 *           "created_at": "2000-09-18T11:01:26.770009",
-		 *           "expires_at": "1998-02-12T15:30:35.488298",
-		 *           "updated_at": "1998-01-13T16:44:47.279514"
+		 *           "created_at": "2024-07-05T04:55:55.103809",
+		 *           "email": "gxJYBtOOVLgZWwIRVLed"
 		 *         }
 		 *       ]
 		 *     }
@@ -1615,15 +1612,14 @@ export interface components {
 			/**
 			 * @example [
 			 *       {
-			 *         "id": "65a3a495-ef67-4106-9c17-ae6e5daffa15",
-			 *         "identity_id": "2be2d8c9-a36b-4de4-99e5-8ba2531670d8",
-			 *         "media_server_id": "9b266ccc-1e0e-47c5-a861-5e14c5d09b94",
-			 *         "external_user_id": "PriLBPewTdWxyxwFswQX",
-			 *         "username": "AufHcSHjwVUDXFiXlEfD",
+			 *         "id": "2cd2e360-9aaa-4d63-bc6c-31927121598e",
+			 *         "identity_id": "d28288ff-6c6f-4485-92fc-b96e5a91b155",
+			 *         "media_server_id": "8f0bfb91-f4a5-4a2f-97e5-a485d32faef3",
+			 *         "external_user_id": "AufHcSHjwVUDXFiXlEfD",
+			 *         "username": "RpSuNeNziQYWrbRjKhHK",
 			 *         "enabled": true,
-			 *         "created_at": "2005-06-01T10:39:16.848019",
-			 *         "external_user_type": "SuNeNziQYWrbRjKhHKYu",
-			 *         "updated_at": "2020-09-24T10:34:21.527288"
+			 *         "created_at": "2008-04-02T03:14:09.626666",
+			 *         "external_user_type": "QmvHLBSfRBympIYulANf"
 			 *       }
 			 *     ]
 			 */
@@ -1824,6 +1820,7 @@ export interface components {
 			created_at: string;
 			identity: components['schemas']['IdentityResponse'];
 			media_server: components['schemas']['MediaServerResponse'];
+			email?: string | null;
 			external_user_type?: string | null;
 			expires_at?: string | null;
 			updated_at?: string | null;
@@ -1851,6 +1848,7 @@ export interface components {
 			enabled: boolean;
 			/** Format: date-time */
 			created_at: string;
+			email?: string | null;
 			external_user_type?: string | null;
 			expires_at?: string | null;
 			updated_at?: string | null;
@@ -3925,6 +3923,8 @@ export interface operations {
 				enabled?: boolean | null;
 				/** @description Filter by expiration status */
 				expired?: boolean | null;
+				/** @description Broad case-insensitive search across users, identities, servers, and invitation codes */
+				search?: string | null;
 				/** @description Field to sort by (created_at, username, expires_at) */
 				sort_by?: string;
 				/** @description Sort order (asc, desc) */

--- a/frontend/src/lib/components/invitations/invitation-form-simple.svelte
+++ b/frontend/src/lib/components/invitations/invitation-form-simple.svelte
@@ -146,6 +146,11 @@ function toLocalDateTimeString(date: Date): string {
 	return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
+function normalizeExpiration(value = expiresAtLocal) {
+	expiresAtLocal = value;
+	formData.expires_at = value ? toISOString(value) : "";
+}
+
 // Compute minimum datetime for expiration input (current time, local timezone)
 const minDateTime = $derived(toLocalDateTimeString(new Date()));
 
@@ -159,6 +164,7 @@ let expiresAtLocal = $state(
  */
 function handleSubmit(e: Event) {
 	e.preventDefault();
+	normalizeExpiration();
 	onSubmit();
 }
 
@@ -295,10 +301,10 @@ function getFieldErrors(field: string): string[] {
 			type="datetime-local"
 			bind:value={expiresAtLocal}
 			oninput={(e) => {
-				const value = e.currentTarget.value;
-				(formData as CreateInvitationInput).expires_at = value
-					? toISOString(value)
-					: "";
+				normalizeExpiration(e.currentTarget.value);
+			}}
+			onchange={(e) => {
+				normalizeExpiration(e.currentTarget.value);
 			}}
 			min={minDateTime}
 			class="border-cr-border bg-cr-surface text-cr-text"

--- a/frontend/src/lib/components/invitations/invitation-form.svelte.test.ts
+++ b/frontend/src/lib/components/invitations/invitation-form.svelte.test.ts
@@ -9,15 +9,16 @@
  * @module $lib/components/invitations/invitation-form.svelte.test
  */
 
-import { cleanup } from '@testing-library/svelte';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
 import * as fc from 'fast-check';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	type CreateInvitationInput,
 	createInvitationSchema,
 	type UpdateInvitationInput,
 	updateInvitationSchema
 } from '$lib/schemas/invitation';
+import InvitationFormSimple from './invitation-form-simple.svelte';
 
 // =============================================================================
 // Test Data Generators
@@ -222,6 +223,46 @@ describe('Property 14: Form Validation Error Display', () => {
 			}),
 			{ numRuns: 50 }
 		);
+	});
+
+	it('keeps selected expiration as an ISO payload before submit', async () => {
+		const serverId = '00000000-0000-4000-8000-000000000001';
+		const formData: CreateInvitationInput = {
+			server_ids: [serverId],
+			code: '',
+			expires_at: '',
+			max_uses: undefined,
+			duration_days: undefined,
+			library_ids: []
+		};
+		const onSubmit = vi.fn();
+
+		const { container } = render(InvitationFormSimple, {
+			props: {
+				formData,
+				errors: {},
+				servers: [
+					{
+						id: serverId,
+						name: 'Plex',
+						server_type: 'plex',
+						url: 'http://plex.local',
+						enabled: true,
+						created_at: new Date().toISOString(),
+						libraries: []
+					}
+				],
+				mode: 'create',
+				onSubmit
+			}
+		});
+
+		const expiresInput = container.querySelector('[data-field-expires-at]') as HTMLInputElement;
+		await fireEvent.input(expiresInput, { target: { value: '2030-01-02T03:04' } });
+		await fireEvent.submit(container.querySelector('[data-invitation-form]')!);
+
+		expect(onSubmit).toHaveBeenCalledOnce();
+		expect(formData.expires_at).toBe(new Date('2030-01-02T03:04').toISOString());
 	});
 });
 

--- a/frontend/src/lib/components/servers/create-server-dialog.svelte
+++ b/frontend/src/lib/components/servers/create-server-dialog.svelte
@@ -207,10 +207,11 @@ async function handleTestConnection() {
 	const testedUrl = formData.url ?? "";
 	const testedApiKey = formData.api_key;
 	const testedUseEnv = formData.use_env_credentials;
+	const testedServerType = formData.server_type;
 
 	try {
 		const testPayload: ConnectionTestRequest = testedUseEnv
-			? { server_type: formData.server_type, use_env_credentials: true as const }
+			? { server_type: testedServerType, use_env_credentials: true as const }
 			: { url: testedUrl, api_key: testedApiKey ?? null };
 
 		const result = await withErrorHandling(
@@ -219,7 +220,12 @@ async function handleTestConnection() {
 		);
 
 		// Discard stale results if inputs changed during the request
-		if (formData.url !== testedUrl || formData.api_key !== testedApiKey || formData.use_env_credentials !== testedUseEnv) {
+		if (
+			formData.url !== testedUrl ||
+			formData.api_key !== testedApiKey ||
+			formData.use_env_credentials !== testedUseEnv ||
+			formData.server_type !== testedServerType
+		) {
 			return;
 		}
 

--- a/frontend/src/lib/components/servers/create-server-dialog.svelte
+++ b/frontend/src/lib/components/servers/create-server-dialog.svelte
@@ -13,7 +13,11 @@
  */
 
 import { Eye, EyeOff, Info, KeyRound, Plug, Plus, Server, X } from "@lucide/svelte";
-import type { ConnectionTestResponse, EnvCredentialResponse } from "$lib/api/client";
+import type {
+	ConnectionTestRequest,
+	ConnectionTestResponse,
+	EnvCredentialResponse,
+} from "$lib/api/client";
 import { createServer, getEnvCredentials, testConnection, withErrorHandling } from "$lib/api/client";
 import { asErrorResponse } from "$lib/api/errors";
 import { Button } from "$lib/components/ui/button";
@@ -123,7 +127,7 @@ async function fetchEnvCredentials() {
  */
 function handleUseEnvCredentials(credential: EnvCredentialResponse) {
 	formData.server_type = credential.server_type;
-	if (credential.url) formData.url = credential.url;
+	formData.url = "";
 	formData.use_env_credentials = true;
 	formData.api_key = "";
 	if (!formData.name) formData.name = credential.display_name;
@@ -179,7 +183,9 @@ function getFieldErrors(field: string): string[] {
  * Whether the "Test Connection" button should be enabled.
  */
 const canTest = $derived(
-	formData.url.trim().length > 0 && (formData.use_env_credentials || (formData.api_key ?? '').trim().length > 0)
+	formData.use_env_credentials ||
+		((formData.url ?? "").trim().length > 0 &&
+			(formData.api_key ?? "").trim().length > 0),
 );
 
 /**
@@ -194,14 +200,14 @@ async function handleTestConnection() {
 	testing = true;
 	testResult = null;
 
-	const testedUrl = formData.url;
+	const testedUrl = formData.url ?? "";
 	const testedApiKey = formData.api_key;
 	const testedUseEnv = formData.use_env_credentials;
 
 	try {
-		const testPayload = testedUseEnv
-			? { url: testedUrl, server_type: formData.server_type, use_env_credentials: true as const }
-			: { url: testedUrl, api_key: testedApiKey };
+		const testPayload: ConnectionTestRequest = testedUseEnv
+			? { server_type: formData.server_type, use_env_credentials: true as const }
+			: { url: testedUrl, api_key: testedApiKey ?? null };
 
 		const result = await withErrorHandling(
 			() => testConnection(testPayload),
@@ -338,11 +344,8 @@ function handleCancel() {
 							>
 								{credential.display_name}
 							</span>
-							<span class="min-w-0 flex-1 truncate font-mono text-xs text-cr-text-muted">
-								{credential.url}
-							</span>
-							<span class="shrink-0 font-mono text-xs text-cr-text-muted/60">
-								{credential.masked_api_key}
+							<span class="min-w-0 flex-1 text-xs text-cr-text-muted">
+								Configured in environment
 							</span>
 						</button>
 					{/each}
@@ -403,17 +406,24 @@ function handleCancel() {
 			<!-- Server URL -->
 			<div class="space-y-2">
 				<Label for="url" class="text-cr-text">Server URL</Label>
-				<Input
-					id="url"
-					type="url"
-					bind:value={formData.url}
-					oninput={onConnectionFieldChange}
-					placeholder="https://media.example.com"
-					disabled={submitting}
-					class="border-cr-border bg-cr-bg text-cr-text placeholder:text-cr-text-muted/50 focus:border-cr-accent font-mono text-sm"
-					data-field="url"
-				/>
-				<p class="text-cr-text-muted text-xs">Full URL including protocol (http:// or https://)</p>
+				{#if formData.use_env_credentials}
+					<div class="flex items-center gap-2 rounded-md border border-cr-accent/30 bg-cr-accent/5 px-3 py-2">
+						<KeyRound class="size-4 text-cr-accent shrink-0" />
+						<span class="flex-1 text-sm text-cr-text">Configured in environment</span>
+					</div>
+				{:else}
+					<Input
+						id="url"
+						type="url"
+						bind:value={formData.url}
+						oninput={onConnectionFieldChange}
+						placeholder="https://media.example.com"
+						disabled={submitting}
+						class="border-cr-border bg-cr-bg text-cr-text placeholder:text-cr-text-muted/50 focus:border-cr-accent font-mono text-sm"
+						data-field="url"
+					/>
+					<p class="text-cr-text-muted text-xs">Full URL including protocol (http:// or https://)</p>
+				{/if}
 				{#if getFieldErrors('url').length > 0}
 					<div class="text-rose-400 text-sm" data-field-error="url">
 						{#each getFieldErrors('url') as error}

--- a/frontend/src/lib/components/servers/create-server-dialog.svelte
+++ b/frontend/src/lib/components/servers/create-server-dialog.svelte
@@ -131,6 +131,10 @@ function handleUseEnvCredentials(credential: EnvCredentialResponse) {
 	formData.use_env_credentials = true;
 	formData.api_key = "";
 	if (!formData.name) formData.name = credential.display_name;
+	const nextErrors = { ...errors };
+	delete nextErrors.url;
+	delete nextErrors.api_key;
+	errors = nextErrors;
 	testResult = null;
 	envDismissed = true;
 }

--- a/frontend/src/lib/components/setup/setup-wizard.svelte.test.ts
+++ b/frontend/src/lib/components/setup/setup-wizard.svelte.test.ts
@@ -201,6 +201,94 @@ describe('SetupWizard', () => {
 		expect(authApi.advanceOnboarding).not.toHaveBeenCalled();
 	});
 
+	it('uses environment credentials without rendering or submitting URL/token values', async () => {
+		const user = userEvent.setup();
+
+		setProviders([
+			{
+				server_type: 'plex',
+				display_name: 'Plex',
+				color: '#e5a00d',
+				icon_svg: ''
+			}
+		]);
+
+		vi.mocked(apiClient.withErrorHandling).mockImplementation(async (fn) => fn() as never);
+		vi.mocked(apiClient.getEnvCredentials).mockResolvedValue({
+			data: {
+				credentials: [
+					{
+						server_type: 'plex',
+						display_name: 'Plex',
+						has_url: true,
+						has_api_key: true
+					}
+				]
+			},
+			error: undefined
+		});
+		vi.mocked(apiClient.testConnection).mockResolvedValue({
+			data: {
+				success: true,
+				message: 'Connection successful',
+				server_type: 'plex',
+				server_name: 'My Plex'
+			},
+			error: undefined,
+			response: new Response()
+		});
+		vi.mocked(apiClient.createServer).mockResolvedValue({
+			data: {
+				id: '00000000-0000-4000-8000-000000000001',
+				name: 'Env Plex',
+				server_type: 'plex',
+				url: 'http://plex.local:32400',
+				enabled: true,
+				created_at: new Date().toISOString(),
+				libraries: []
+			},
+			error: undefined,
+			response: new Response()
+		});
+
+		const { container } = render(SetupWizard, { props: { initialStep: 'server' } });
+
+		await waitFor(() => {
+			expect(container.textContent).toContain('Environment credentials detected');
+		});
+
+		expect(container.textContent).not.toContain('http://plex.local:32400');
+		expect(container.textContent).not.toContain('abcd********mnop');
+
+		const nameInput = container.querySelector('#server-name') as HTMLInputElement;
+		await user.type(nameInput, 'Env Plex');
+		await user.click(findButton(container, 'Plex')!);
+
+		expect(container.querySelector('#server-url')).toBeNull();
+		expect(container.querySelector('#server-api-key')).toBeNull();
+		expect(container.textContent).toContain('Configured in environment');
+
+		await user.click(findButton(container, 'Test Connection')!);
+
+		await waitFor(() => {
+			expect(container.textContent).toContain('Connected');
+		});
+
+		await user.click(findButton(container, 'Add Server & Finish')!);
+
+		await waitFor(() => {
+			expect(apiClient.testConnection).toHaveBeenCalledWith({
+				server_type: 'plex',
+				use_env_credentials: true
+			});
+			expect(apiClient.createServer).toHaveBeenCalledWith({
+				name: 'Env Plex',
+				server_type: 'plex',
+				use_env_credentials: true
+			});
+		});
+	});
+
 	it('starts at the security step when initialStep is security', () => {
 		const { container } = render(SetupWizard, {
 			props: { initialStep: 'security' }

--- a/frontend/src/lib/components/setup/step-server.svelte
+++ b/frontend/src/lib/components/setup/step-server.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { Eye, EyeOff, Info, KeyRound, Plug, X } from '@lucide/svelte';
-import type { ConnectionTestResponse, EnvCredentialResponse } from '$lib/api/client';
+import type { ConnectionTestRequest, ConnectionTestResponse, EnvCredentialResponse } from '$lib/api/client';
 import { createServer, getEnvCredentials, testConnection, withErrorHandling } from '$lib/api/client';
 import { asErrorResponse } from '$lib/api/errors';
 import { Button } from '$lib/components/ui/button';
@@ -68,7 +68,7 @@ async function fetchEnvCredentials() {
 
 function handleUseEnvCredentials(credential: EnvCredentialResponse) {
 	formData.server_type = credential.server_type;
-	if (credential.url) formData.url = credential.url;
+	formData.url = '';
 	formData.use_env_credentials = true;
 	formData.api_key = '';
 	if (!formData.name) formData.name = credential.display_name;
@@ -109,7 +109,7 @@ function getFieldErrors(field: string): string[] {
 }
 
 const canTest = $derived(
-	formData.url.trim().length > 0 && (formData.use_env_credentials || (formData.api_key ?? '').trim().length > 0)
+	formData.use_env_credentials || ((formData.url ?? '').trim().length > 0 && (formData.api_key ?? '').trim().length > 0)
 );
 const connectionVerified = $derived(testResult?.success === true);
 
@@ -117,14 +117,14 @@ async function handleTestConnection() {
 	testing = true;
 	testResult = null;
 
-	const testedUrl = formData.url;
+	const testedUrl = formData.url ?? '';
 	const testedApiKey = formData.api_key;
 	const testedUseEnv = formData.use_env_credentials;
 
 	try {
-		const testPayload = testedUseEnv
-			? { url: testedUrl, server_type: formData.server_type, use_env_credentials: true as const }
-			: { url: testedUrl, api_key: testedApiKey };
+		const testPayload: ConnectionTestRequest = testedUseEnv
+			? { server_type: formData.server_type, use_env_credentials: true as const }
+			: { url: testedUrl, api_key: testedApiKey ?? null };
 
 		const result = await withErrorHandling(
 			() => testConnection(testPayload),
@@ -229,11 +229,8 @@ async function handleSubmit(event: Event) {
 							>
 								{credential.display_name}
 							</span>
-							<span class="min-w-0 flex-1 truncate font-mono text-xs text-cr-text-muted">
-								{credential.url}
-							</span>
-							<span class="shrink-0 font-mono text-xs text-cr-text-muted/60">
-								{credential.masked_api_key}
+							<span class="min-w-0 flex-1 text-xs text-cr-text-muted">
+								Configured in environment
 							</span>
 						</button>
 					{/each}
@@ -293,18 +290,25 @@ async function handleSubmit(event: Event) {
 			<!-- Server URL -->
 			<div class="space-y-2">
 				<Label for="server-url" class="text-cr-text">Server URL</Label>
-				<Input
-					id="server-url"
-					type="url"
-					bind:value={formData.url}
-					oninput={onConnectionFieldChange}
-					placeholder="https://media.example.com"
-					disabled={submitting}
-					class="border-cr-border bg-cr-bg text-cr-text placeholder:text-cr-text-muted/50 focus:border-cr-accent font-mono text-sm"
-				/>
-				<p class="text-xs text-cr-text-muted">
-					Full URL including protocol (http:// or https://)
-				</p>
+				{#if formData.use_env_credentials}
+					<div class="flex items-center gap-2 rounded-md border border-cr-accent/30 bg-cr-accent/5 px-3 py-2">
+						<KeyRound class="size-4 shrink-0 text-cr-accent" />
+						<span class="flex-1 text-sm text-cr-text">Configured in environment</span>
+					</div>
+				{:else}
+					<Input
+						id="server-url"
+						type="url"
+						bind:value={formData.url}
+						oninput={onConnectionFieldChange}
+						placeholder="https://media.example.com"
+						disabled={submitting}
+						class="border-cr-border bg-cr-bg text-cr-text placeholder:text-cr-text-muted/50 focus:border-cr-accent font-mono text-sm"
+					/>
+					<p class="text-xs text-cr-text-muted">
+						Full URL including protocol (http:// or https://)
+					</p>
+				{/if}
 				{#if getFieldErrors('url').length > 0}
 					<div class="text-sm text-rose-400">
 						{#each getFieldErrors('url') as error}

--- a/frontend/src/lib/components/setup/step-server.svelte
+++ b/frontend/src/lib/components/setup/step-server.svelte
@@ -120,10 +120,11 @@ async function handleTestConnection() {
 	const testedUrl = formData.url ?? '';
 	const testedApiKey = formData.api_key;
 	const testedUseEnv = formData.use_env_credentials;
+	const testedServerType = formData.server_type;
 
 	try {
 		const testPayload: ConnectionTestRequest = testedUseEnv
-			? { server_type: formData.server_type, use_env_credentials: true as const }
+			? { server_type: testedServerType, use_env_credentials: true as const }
 			: { url: testedUrl, api_key: testedApiKey ?? null };
 
 		const result = await withErrorHandling(
@@ -131,7 +132,12 @@ async function handleTestConnection() {
 			{ showErrorToast: false }
 		);
 
-		if (formData.url !== testedUrl || formData.api_key !== testedApiKey || formData.use_env_credentials !== testedUseEnv) {
+		if (
+			formData.url !== testedUrl ||
+			formData.api_key !== testedApiKey ||
+			formData.use_env_credentials !== testedUseEnv ||
+			formData.server_type !== testedServerType
+		) {
 			return;
 		}
 

--- a/frontend/src/lib/components/setup/step-server.svelte
+++ b/frontend/src/lib/components/setup/step-server.svelte
@@ -72,6 +72,10 @@ function handleUseEnvCredentials(credential: EnvCredentialResponse) {
 	formData.use_env_credentials = true;
 	formData.api_key = '';
 	if (!formData.name) formData.name = credential.display_name;
+	const nextErrors = { ...errors };
+	delete nextErrors.url;
+	delete nextErrors.api_key;
+	errors = nextErrors;
 	testResult = null;
 	envDismissed = true;
 }

--- a/frontend/src/lib/components/users/user-filters.svelte
+++ b/frontend/src/lib/components/users/user-filters.svelte
@@ -15,13 +15,14 @@
  * @module $lib/components/users/user-filters
  */
 
-import { ArrowDownAZ, ArrowUpAZ, Filter } from "@lucide/svelte";
+import { ArrowDownAZ, ArrowUpAZ, Filter, Search, X } from "@lucide/svelte";
 import type {
 	InvitationResponse,
 	ListUsersParams,
 	MediaServerWithLibrariesResponse,
 } from "$lib/api/client";
 import { Button } from "$lib/components/ui/button";
+import { Input } from "$lib/components/ui/input";
 import * as Select from "$lib/components/ui/select";
 import { getProviderBadgeStyle } from "$lib/stores/providers.svelte";
 
@@ -30,6 +31,7 @@ interface Props {
 	invitationId?: string;
 	enabled?: boolean;
 	expired?: boolean;
+	search?: string;
 	sortBy: "created_at" | "username" | "expires_at";
 	sortOrder: "asc" | "desc";
 	servers: MediaServerWithLibrariesResponse[];
@@ -42,12 +44,28 @@ const {
 	invitationId,
 	enabled,
 	expired,
+	search,
 	sortBy,
 	sortOrder,
 	servers,
 	invitations,
 	onFilterChange,
 }: Props = $props();
+
+let searchValue = $state("");
+let searchTimer: ReturnType<typeof setTimeout> | null = null;
+
+$effect(() => {
+	searchValue = search ?? "";
+});
+
+$effect(() => {
+	return () => {
+		if (searchTimer !== null) {
+			clearTimeout(searchTimer);
+		}
+	};
+});
 
 // Convert boolean to select value
 const enabledValue = $derived.by(() => {
@@ -118,6 +136,26 @@ function handleExpiredChange(value: string | undefined) {
 	}
 }
 
+function handleSearchInput(event: Event) {
+	searchValue = (event.currentTarget as HTMLInputElement).value;
+	if (searchTimer !== null) {
+		clearTimeout(searchTimer);
+	}
+	searchTimer = setTimeout(() => {
+		onFilterChange({ search: searchValue.trim() || undefined });
+		searchTimer = null;
+	}, 250);
+}
+
+function clearSearch() {
+	searchValue = "";
+	if (searchTimer !== null) {
+		clearTimeout(searchTimer);
+		searchTimer = null;
+	}
+	onFilterChange({ search: undefined });
+}
+
 /**
  * Handle sort by change.
  */
@@ -149,6 +187,29 @@ const sortByOptions = [
 	<div class="flex items-center gap-2 text-cr-text-muted">
 		<Filter class="size-4" />
 		<span class="text-sm font-medium">Filters</span>
+	</div>
+
+	<div class="relative min-w-52 flex-1 sm:flex-none">
+		<Search class="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-cr-text-muted" />
+		<Input
+			type="search"
+			value={searchValue}
+			oninput={handleSearchInput}
+			placeholder="Search users"
+			aria-label="Search users"
+			class="h-9 border-cr-border bg-cr-bg pl-8 pr-8 text-cr-text placeholder:text-cr-text-muted/60"
+			data-user-search
+		/>
+		{#if searchValue}
+			<button
+				type="button"
+				onclick={clearSearch}
+				aria-label="Clear search"
+				class="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-cr-text-muted hover:text-cr-text"
+			>
+				<X class="size-3.5" />
+			</button>
+		{/if}
 	</div>
 
 	<!-- Server filter -->

--- a/frontend/src/lib/components/users/user-list.svelte.test.ts
+++ b/frontend/src/lib/components/users/user-list.svelte.test.ts
@@ -10,15 +10,17 @@
  * @module $lib/components/users/user-list.svelte.test
  */
 
-import { cleanup, render } from '@testing-library/svelte';
+import { cleanup, render, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import * as fc from 'fast-check';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
 	IdentityResponse,
 	InvitationResponse,
 	MediaServerResponse,
 	UserDetailResponse
 } from '$lib/api/client';
+import UserFilters from './user-filters.svelte';
 import UserRow from './user-row.svelte';
 import UserTable from './user-table.svelte';
 
@@ -119,6 +121,7 @@ const userDetailResponseArb: fc.Arbitrary<UserDetailResponse> = fc
 		created_at: isoDateArb,
 		identity: identityResponseArb,
 		media_server: mediaServerResponseArb,
+		email: fc.oneof(fc.emailAddress(), fc.constant(null)),
 		expires_at: optionalIsoDateArb,
 		updated_at: optionalIsoDateArb,
 		invitation_id: fc.oneof(uuidArb, fc.constant(null)),
@@ -196,6 +199,27 @@ describe('Property 17: User Field Display', () => {
 				cleanup();
 			}),
 			{ numRuns: 100 }
+		);
+	});
+
+	it('should display email under username when present', () => {
+		fc.assert(
+			fc.property(
+				userDetailResponseArb.map((user) => ({
+					...user,
+					email: 'plexuser@example.com'
+				})),
+				(user) => {
+					const { container } = render(UserRow, { props: { user } });
+					const emailEl = container.querySelector('[data-user-email]');
+
+					expect(emailEl).not.toBeNull();
+					expect(emailEl?.textContent).toContain('plexuser@example.com');
+
+					cleanup();
+				}
+			),
+			{ numRuns: 25 }
 		);
 	});
 
@@ -285,6 +309,28 @@ describe('Property 17: User Field Display', () => {
 describe('Property 18: User Filter Application', () => {
 	afterEach(() => {
 		cleanup();
+	});
+
+	it('emits search filter changes for URL param sync', async () => {
+		const user = userEvent.setup();
+		const onFilterChange = vi.fn();
+		const { container } = render(UserFilters, {
+			props: {
+				search: '',
+				sortBy: 'created_at',
+				sortOrder: 'desc',
+				servers: [],
+				invitations: [],
+				onFilterChange
+			}
+		});
+
+		const searchInput = container.querySelector('[data-user-search]') as HTMLInputElement;
+		await user.type(searchInput, 'plex@example.com');
+
+		await waitFor(() => {
+			expect(onFilterChange).toHaveBeenLastCalledWith({ search: 'plex@example.com' });
+		});
 	});
 
 	/**

--- a/frontend/src/lib/components/users/user-row.svelte
+++ b/frontend/src/lib/components/users/user-row.svelte
@@ -101,6 +101,7 @@ const expiresDisplay = $derived.by(() => {
 });
 
 const badgeStyle = $derived(getProviderBadgeStyle(user.media_server.server_type));
+const userEmail = $derived(user.email ?? user.identity.email);
 
 /**
  * Navigate to user detail page.
@@ -145,9 +146,16 @@ function handleDelete() {
 >
 	<!-- Username -->
 	<Table.Cell>
-		<span class="font-medium text-cr-text" data-user-username>
-			{user.username}
-		</span>
+		<div class="min-w-0">
+			<span class="block truncate font-medium text-cr-text" data-user-username>
+				{user.username}
+			</span>
+			{#if userEmail}
+				<span class="block truncate text-xs text-cr-text-muted" data-user-email>
+					{userEmail}
+				</span>
+			{/if}
+		</div>
 	</Table.Cell>
 
 	<!-- Server -->

--- a/frontend/src/lib/schemas/server.ts
+++ b/frontend/src/lib/schemas/server.ts
@@ -16,7 +16,7 @@ import { getAllProviders } from '$lib/stores/providers.svelte';
  * Required fields:
  * - name: Human-readable name for the server
  * - server_type: Type of media server (as registered by a provider)
- * - url: Base URL for the media server API
+ * - url: Base URL for the media server API (required unless use_env_credentials is true)
  * - api_key: Authentication token for the server (required unless use_env_credentials is true)
  * - use_env_credentials: Whether to use server-side env var credentials
  */
@@ -27,13 +27,17 @@ export const createServerSchema = z
 			.string()
 			.min(1, 'Server type is required')
 			.refine((val) => getAllProviders().some((p) => p.server_type === val), 'Invalid server type'),
-		url: z
-			.string()
-			.min(1, 'URL is required')
-			.url('Must be a valid URL')
-			.max(2048, 'URL must be at most 2048 characters'),
+		url: z.string().max(2048, 'URL must be at most 2048 characters').optional().default(''),
 		api_key: z.string().max(512, 'API key must be at most 512 characters').default(''),
 		use_env_credentials: z.boolean().default(false)
+	})
+	.refine((d) => d.use_env_credentials || d.url.length >= 1, {
+		message: 'URL is required',
+		path: ['url']
+	})
+	.refine((d) => d.use_env_credentials || z.string().url().safeParse(d.url).success, {
+		message: 'Must be a valid URL',
+		path: ['url']
 	})
 	.refine((d) => d.use_env_credentials || d.api_key.length >= 1, {
 		message: 'API key is required',
@@ -51,13 +55,12 @@ export type CreateServerInput = z.input<typeof createServerSchema>;
 export function transformCreateServerData(data: CreateServerInput) {
 	const base = {
 		name: data.name.trim(),
-		server_type: data.server_type,
-		url: data.url.trim()
+		server_type: data.server_type
 	};
 
 	if (data.use_env_credentials) {
 		return { ...base, use_env_credentials: true };
 	}
 
-	return { ...base, api_key: (data.api_key ?? '').trim() };
+	return { ...base, url: (data.url ?? '').trim(), api_key: (data.api_key ?? '').trim() };
 }

--- a/frontend/src/lib/schemas/server.ts
+++ b/frontend/src/lib/schemas/server.ts
@@ -35,10 +35,13 @@ export const createServerSchema = z
 		message: 'URL is required',
 		path: ['url']
 	})
-	.refine((d) => d.use_env_credentials || z.string().url().safeParse(d.url).success, {
-		message: 'Must be a valid URL',
-		path: ['url']
-	})
+	.refine(
+		(d) => d.use_env_credentials || d.url.length === 0 || z.string().url().safeParse(d.url).success,
+		{
+			message: 'Must be a valid URL',
+			path: ['url']
+		}
+	)
 	.refine((d) => d.use_env_credentials || d.api_key.length >= 1, {
 		message: 'API key is required',
 		path: ['api_key']

--- a/frontend/src/routes/(admin)/users/+page.svelte
+++ b/frontend/src/routes/(admin)/users/+page.svelte
@@ -67,7 +67,7 @@ function handleFilterChange(newParams: Partial<ListUsersParams>) {
 
 	// Update or remove each param
 	for (const [key, value] of Object.entries(newParams)) {
-		if (value === undefined || value === null) {
+		if (value === undefined || value === null || value === "") {
 			url.searchParams.delete(key);
 		} else {
 			url.searchParams.set(key, String(value));
@@ -165,6 +165,7 @@ async function handleDeleteConfirm() {
 		invitationId={currentParams.invitation_id}
 		enabled={currentParams.enabled}
 		expired={currentParams.expired}
+		search={currentParams.search}
 		sortBy={currentParams.sort_by ?? 'created_at'}
 		sortOrder={currentParams.sort_order ?? 'desc'}
 		servers={data.servers}

--- a/frontend/src/routes/(admin)/users/+page.ts
+++ b/frontend/src/routes/(admin)/users/+page.ts
@@ -28,6 +28,7 @@ export const load: PageLoad = async ({ fetch, url }) => {
 	const invitationId = url.searchParams.get('invitation_id');
 	const enabledParam = url.searchParams.get('enabled');
 	const expiredParam = url.searchParams.get('expired');
+	const search = url.searchParams.get('search');
 	const sortBy = url.searchParams.get('sort_by') as ListUsersParams['sort_by'] | null;
 	const sortOrder = url.searchParams.get('sort_order') as ListUsersParams['sort_order'] | null;
 
@@ -51,6 +52,10 @@ export const load: PageLoad = async ({ fetch, url }) => {
 
 	if (expiredParam !== null) {
 		params.expired = expiredParam === 'true';
+	}
+
+	if (search) {
+		params.search = search;
 	}
 
 	if (sortBy) {


### PR DESCRIPTION
## Summary

This PR fixes the three dogfood findings around setup-time environment credentials, user search/email handling, and invitation expiration handling.

## Changes

- Limits the environment credential discovery endpoint to availability metadata only, removing setup-time URL and token rendering.
- Allows env-backed server create and connection test flows to omit URL and API key, resolving both server-side from provider environment credentials.
- Updates setup and server creation UI to show only that credentials are configured in the environment and to submit only provider/env-mode metadata.
- Adds a broad user search parameter that composes with existing filters and matches username, external user ID, identity name/email, server name/type, and invitation code.
- Adds top-level user email in user detail/list responses while preserving identity.email.
- Displays user email under username when available.
- Backfills missing identity email from provider-reported ExternalUser.email during redemption and non-dry-run sync.
- Normalizes invitation datetime-local expiration values on input, change, and submit so selected expirations are sent as ISO timestamps.
- Regenerates frontend OpenAPI types.

## Verification

- uv run pytest tests/test_env_credentials.py tests/test_user_search.py tests/test_sync_email_backfill.py tests/test_redemption_retry.py -q
- uv run ruff check src/zondarr/api/schemas.py src/zondarr/api/servers.py src/zondarr/api/users.py src/zondarr/services/user.py src/zondarr/repositories/user.py src/zondarr/services/redemption.py src/zondarr/services/sync.py tests/test_env_credentials.py tests/test_user_search.py tests/test_sync_email_backfill.py tests/test_redemption_retry.py
- uv run basedpyright src/zondarr/api/schemas.py src/zondarr/api/servers.py src/zondarr/api/users.py src/zondarr/services/user.py src/zondarr/repositories/user.py src/zondarr/services/redemption.py src/zondarr/services/sync.py tests/test_env_credentials.py tests/test_user_search.py tests/test_sync_email_backfill.py tests/test_redemption_retry.py
- bun run --cwd frontend check
- bun run --cwd frontend test -- src/lib/components/setup/setup-wizard.svelte.test.ts src/lib/components/users/user-list.svelte.test.ts src/lib/components/invitations/invitation-form.svelte.test.ts
- bun run --cwd frontend test -- src/lib/api/client.test.ts
- git diff --check