### PR TITLE
fix(users): gate enable disable by provider capability

### DIFF
--- a/backend/src/zondarr/services/user.py
+++ b/backend/src/zondarr/services/user.py
@@ -25,7 +25,7 @@ import structlog
 from zondarr.core.exceptions import NotFoundError, ValidationError
 from zondarr.media.exceptions import MediaClientError
 from zondarr.media.registry import registry
-from zondarr.media.types import ExternalUser
+from zondarr.media.types import Capability, ExternalUser
 from zondarr.models.identity import Identity, User
 from zondarr.models.media_server import MediaServer
 from zondarr.repositories.identity import IdentityRepository
@@ -276,6 +276,12 @@ class UserService:
 
         # Update external media server first (atomicity guarantee)
         server = user.media_server
+        capabilities = registry.get_capabilities(server.server_type)
+        if Capability.ENABLE_DISABLE_USER not in capabilities:
+            provider_name = server.server_type.capitalize()
+            message = f"Enable/disable is not supported for {provider_name} servers"
+            raise ValidationError(message, field_errors={"user_id": [message]})
+
         client = registry.create_client_for_server(server)
 
         try:

--- a/backend/src/zondarr/services/user.py
+++ b/backend/src/zondarr/services/user.py
@@ -280,7 +280,7 @@ class UserService:
         if Capability.ENABLE_DISABLE_USER not in capabilities:
             provider_name = server.server_type.capitalize()
             message = f"Enable/disable is not supported for {provider_name} servers"
-            raise ValidationError(message, field_errors={"user_id": [message]})
+            raise ValidationError(message, field_errors={})
 
         client = registry.create_client_for_server(server)
 

--- a/backend/tests/property/test_user_service_props.py
+++ b/backend/tests/property/test_user_service_props.py
@@ -612,6 +612,7 @@ class TestEnableDisableAtomicity:
                 exc_info.value.message
                 == "Enable/disable is not supported for Plex servers"
             )
+            assert exc_info.value.field_errors == {}
             mock_registry.create_client_for_server.assert_not_called()  # pyright: ignore[reportAny]
 
         async with db.session_factory() as session:

--- a/backend/tests/property/test_user_service_props.py
+++ b/backend/tests/property/test_user_service_props.py
@@ -26,6 +26,7 @@ from tests.conftest import TestDB
 from zondarr.core.exceptions import ValidationError
 from zondarr.media.exceptions import MediaClientError
 from zondarr.media.registry import ClientRegistry
+from zondarr.media.types import Capability
 from zondarr.models.identity import Identity, User
 from zondarr.models.media_server import MediaServer
 from zondarr.repositories.identity import IdentityRepository
@@ -167,6 +168,7 @@ async def create_test_user_with_server(
     username: str,
     external_user_id: str,
     initial_enabled: bool,
+    server_type: str = "jellyfin",
 ) -> tuple[User, MediaServer, Identity]:
     """Create a test user with associated media server and identity.
 
@@ -183,8 +185,8 @@ async def create_test_user_with_server(
         # Create media server
         server = MediaServer(
             name="TestServer",
-            server_type="jellyfin",
-            url="http://jellyfin.local:8096",
+            server_type=server_type,
+            url=f"http://{server_type}.local:8096",
             api_key="test-api-key",
             enabled=True,
         )
@@ -269,6 +271,9 @@ class TestEnableDisableAtomicity:
 
         # Create mock registry that returns successful client
         mock_registry = MagicMock(spec=ClientRegistry)
+        mock_registry.get_capabilities = MagicMock(
+            return_value={Capability.ENABLE_DISABLE_USER}
+        )
         mock_registry.create_client_for_server = MagicMock(
             return_value=create_mock_client_success(enabled=target_enabled)
         )
@@ -335,6 +340,9 @@ class TestEnableDisableAtomicity:
 
         # Create mock registry that returns failing client
         mock_registry = MagicMock(spec=ClientRegistry)
+        mock_registry.get_capabilities = MagicMock(
+            return_value={Capability.ENABLE_DISABLE_USER}
+        )
         mock_registry.create_client_for_server = MagicMock(
             return_value=create_mock_client_failure(
                 error_message="Jellyfin server unavailable"
@@ -401,6 +409,9 @@ class TestEnableDisableAtomicity:
 
         # Create mock registry that returns "user not found" response
         mock_registry = MagicMock(spec=ClientRegistry)
+        mock_registry.get_capabilities = MagicMock(
+            return_value={Capability.ENABLE_DISABLE_USER}
+        )
         mock_registry.create_client_for_server = MagicMock(
             return_value=create_mock_client_user_not_found()
         )
@@ -463,6 +474,9 @@ class TestEnableDisableAtomicity:
 
         # Create mock registry that returns successful client
         mock_registry = MagicMock(spec=ClientRegistry)
+        mock_registry.get_capabilities = MagicMock(
+            return_value={Capability.ENABLE_DISABLE_USER}
+        )
         mock_registry.create_client_for_server = MagicMock(
             return_value=create_mock_client_success(enabled=initial_enabled)
         )
@@ -519,6 +533,9 @@ class TestEnableDisableAtomicity:
 
         # Create mock registry that returns successful client
         mock_registry = MagicMock(spec=ClientRegistry)
+        mock_registry.get_capabilities = MagicMock(
+            return_value={Capability.ENABLE_DISABLE_USER}
+        )
         mock_registry.create_client_for_server = MagicMock(
             return_value=create_mock_client_success(enabled=target_enabled)
         )
@@ -543,6 +560,67 @@ class TestEnableDisableAtomicity:
             )
             assert updated_user.enabled != initial_enabled, (
                 f"Expected enabled to change from {initial_enabled}"
+            )
+
+    @given(
+        username=username_strategy,
+        external_user_id=external_user_id_strategy,
+        initial_enabled=st.booleans(),
+        target_enabled=st.booleans(),
+    )
+    @settings(max_examples=15, deadline=None)
+    @pytest.mark.asyncio
+    async def test_unsupported_provider_preserves_local_record_without_client_call(
+        self,
+        db: TestDB,
+        username: str,
+        external_user_id: str,
+        initial_enabled: bool,
+        target_enabled: bool,
+    ) -> None:
+        """When the provider lacks enable/disable support, fail before client use."""
+        await db.clean()
+
+        user, _server, _identity = await create_test_user_with_server(
+            db.session_factory,
+            username=username,
+            external_user_id=external_user_id,
+            initial_enabled=initial_enabled,
+            server_type="plex",
+        )
+        user_id = user.id
+
+        mock_registry = MagicMock(spec=ClientRegistry)
+        mock_registry.get_capabilities = MagicMock(return_value=set())
+        mock_registry.create_client_for_server = MagicMock(
+            return_value=create_mock_client_success(enabled=target_enabled)
+        )
+
+        async with db.session_factory() as session:
+            user_repo = UserRepository(session)
+            identity_repo = IdentityRepository(session)
+            user_service = UserService(user_repo, identity_repo)
+
+            with patch("zondarr.services.user.registry", mock_registry):
+                with pytest.raises(ValidationError) as exc_info:
+                    _ = await user_service.set_enabled(
+                        user_id,
+                        enabled=target_enabled,
+                    )
+
+            assert (
+                exc_info.value.message
+                == "Enable/disable is not supported for Plex servers"
+            )
+            mock_registry.create_client_for_server.assert_not_called()  # pyright: ignore[reportAny]
+
+        async with db.session_factory() as session:
+            user_repo = UserRepository(session)
+            persisted_user = await user_repo.get_by_id(user_id)
+            assert persisted_user is not None
+            assert persisted_user.enabled == initial_enabled, (
+                f"Expected enabled to remain {initial_enabled}, "
+                f"but got {persisted_user.enabled}"
             )
 
 

--- a/frontend/src/lib/components/users/user-detail.svelte.test.ts
+++ b/frontend/src/lib/components/users/user-detail.svelte.test.ts
@@ -20,6 +20,9 @@ import type {
 	MediaServerResponse,
 	UserDetailResponse
 } from '$lib/api/client';
+import { hasProviderCapability, setProviders } from '$lib/stores/providers.svelte';
+
+const ENABLE_DISABLE_CAPABILITY = 'enable_disable_user';
 
 // =============================================================================
 // Test Data Generators
@@ -59,6 +62,18 @@ const invitationCodeArb = fc.stringMatching(/^[a-zA-Z0-9]{1,20}$/);
  * Generate a valid server type.
  */
 const serverTypeArb = fc.constantFrom('jellyfin' as const, 'plex' as const);
+
+const providerCapabilityArb = fc.uniqueArray(
+	fc.constantFrom(
+		'create_user',
+		'delete_user',
+		ENABLE_DISABLE_CAPABILITY,
+		'library_access',
+		'download_permission',
+		'remove_shared_access'
+	),
+	{ maxLength: 6 }
+);
 
 /**
  * Generate a valid MediaServerResponse object.
@@ -169,6 +184,22 @@ const disabledUserArb = userDetailResponseArb.map((user) => ({
 	...user,
 	enabled: false
 }));
+
+/**
+ * Register provider metadata for a user's server type.
+ */
+function setProviderCapabilities(user: UserDetailResponse, capabilities: string[]): void {
+	setProviders([
+		{
+			server_type: user.media_server.server_type,
+			display_name: user.media_server.server_type,
+			color: '#6b7280',
+			icon_svg: '',
+			capabilities,
+			supported_permissions: []
+		}
+	]);
+}
 
 // =============================================================================
 // Property 21: User Detail Relationship Display
@@ -417,15 +448,20 @@ describe('Property 23: Enable Button Visibility', () => {
 	 */
 	it('should show enable button for disabled users', () => {
 		fc.assert(
-			fc.property(disabledUserArb, (user) => {
+			fc.property(disabledUserArb, providerCapabilityArb, (user, capabilities) => {
+				setProviderCapabilities(user, capabilities);
+
 				// Verify user is disabled
 				expect(user.enabled).toBe(false);
 
-				// The enable button should be visible (enabled === false)
-				const shouldShowEnableButton = !user.enabled;
-				const shouldShowDisableButton = user.enabled;
+				const providerSupportsEnableDisable = hasProviderCapability(
+					user.media_server.server_type,
+					ENABLE_DISABLE_CAPABILITY
+				);
+				const shouldShowEnableButton = providerSupportsEnableDisable && !user.enabled;
+				const shouldShowDisableButton = providerSupportsEnableDisable && user.enabled;
 
-				expect(shouldShowEnableButton).toBe(true);
+				expect(shouldShowEnableButton).toBe(capabilities.includes(ENABLE_DISABLE_CAPABILITY));
 				expect(shouldShowDisableButton).toBe(false);
 			}),
 			{ numRuns: 100 }
@@ -438,23 +474,63 @@ describe('Property 23: Enable Button Visibility', () => {
 	 */
 	it('should have consistent enable button visibility for disabled users', () => {
 		fc.assert(
-			fc.property(disabledUserArb, fc.integer({ min: 2, max: 5 }), (user, checkCount) => {
-				const visibilityResults: boolean[] = [];
+			fc.property(
+				disabledUserArb,
+				providerCapabilityArb,
+				fc.integer({ min: 2, max: 5 }),
+				(user, capabilities, checkCount) => {
+					setProviderCapabilities(user, capabilities);
+					const visibilityResults: boolean[] = [];
 
-				for (let i = 0; i < checkCount; i++) {
-					// Check visibility logic
-					const shouldShowEnableButton = !user.enabled;
-					visibilityResults.push(shouldShowEnableButton);
-				}
+					for (let i = 0; i < checkCount; i++) {
+						const shouldShowEnableButton =
+							hasProviderCapability(user.media_server.server_type, ENABLE_DISABLE_CAPABILITY) &&
+							!user.enabled;
+						visibilityResults.push(shouldShowEnableButton);
+					}
 
-				// All checks should return the same result
-				const firstResult = visibilityResults[0];
-				for (const result of visibilityResults) {
-					expect(result).toBe(firstResult);
-					expect(result).toBe(true); // Should always be true for disabled users
+					// All checks should return the same result
+					const firstResult = visibilityResults[0];
+					for (const result of visibilityResults) {
+						expect(result).toBe(firstResult);
+						expect(result).toBe(capabilities.includes(ENABLE_DISABLE_CAPABILITY));
+					}
 				}
-			}),
+			),
 			{ numRuns: 50 }
+		);
+	});
+
+	/**
+	 * Plex does not support native enable/disable, so neither action should
+	 * render while the destructive delete flow remains available.
+	 */
+	it('should hide enable and disable actions for Plex while keeping delete available', () => {
+		fc.assert(
+			fc.property(userDetailResponseArb, (user) => {
+				const plexUser = {
+					...user,
+					media_server: {
+						...user.media_server,
+						server_type: 'plex' as const
+					}
+				};
+				setProviderCapabilities(plexUser, ['create_user', 'delete_user', 'library_access']);
+
+				const providerSupportsEnableDisable = hasProviderCapability(
+					plexUser.media_server.server_type,
+					ENABLE_DISABLE_CAPABILITY
+				);
+				const shouldShowEnableButton = providerSupportsEnableDisable && !plexUser.enabled;
+				const shouldShowDisableButton = providerSupportsEnableDisable && plexUser.enabled;
+				const shouldShowDeleteButton = true;
+
+				expect(providerSupportsEnableDisable).toBe(false);
+				expect(shouldShowEnableButton).toBe(false);
+				expect(shouldShowDisableButton).toBe(false);
+				expect(shouldShowDeleteButton).toBe(true);
+			}),
+			{ numRuns: 100 }
 		);
 	});
 });
@@ -474,16 +550,21 @@ describe('Property 24: Disable Button Visibility', () => {
 	 */
 	it('should show disable button for enabled users', () => {
 		fc.assert(
-			fc.property(enabledUserArb, (user) => {
+			fc.property(enabledUserArb, providerCapabilityArb, (user, capabilities) => {
+				setProviderCapabilities(user, capabilities);
+
 				// Verify user is enabled
 				expect(user.enabled).toBe(true);
 
-				// The disable button should be visible (enabled === true)
-				const shouldShowEnableButton = !user.enabled;
-				const shouldShowDisableButton = user.enabled;
+				const providerSupportsEnableDisable = hasProviderCapability(
+					user.media_server.server_type,
+					ENABLE_DISABLE_CAPABILITY
+				);
+				const shouldShowEnableButton = providerSupportsEnableDisable && !user.enabled;
+				const shouldShowDisableButton = providerSupportsEnableDisable && user.enabled;
 
 				expect(shouldShowEnableButton).toBe(false);
-				expect(shouldShowDisableButton).toBe(true);
+				expect(shouldShowDisableButton).toBe(capabilities.includes(ENABLE_DISABLE_CAPABILITY));
 			}),
 			{ numRuns: 100 }
 		);
@@ -495,22 +576,29 @@ describe('Property 24: Disable Button Visibility', () => {
 	 */
 	it('should have consistent disable button visibility for enabled users', () => {
 		fc.assert(
-			fc.property(enabledUserArb, fc.integer({ min: 2, max: 5 }), (user, checkCount) => {
-				const visibilityResults: boolean[] = [];
+			fc.property(
+				enabledUserArb,
+				providerCapabilityArb,
+				fc.integer({ min: 2, max: 5 }),
+				(user, capabilities, checkCount) => {
+					setProviderCapabilities(user, capabilities);
+					const visibilityResults: boolean[] = [];
 
-				for (let i = 0; i < checkCount; i++) {
-					// Check visibility logic
-					const shouldShowDisableButton = user.enabled;
-					visibilityResults.push(shouldShowDisableButton);
-				}
+					for (let i = 0; i < checkCount; i++) {
+						const shouldShowDisableButton =
+							hasProviderCapability(user.media_server.server_type, ENABLE_DISABLE_CAPABILITY) &&
+							user.enabled;
+						visibilityResults.push(shouldShowDisableButton);
+					}
 
-				// All checks should return the same result
-				const firstResult = visibilityResults[0];
-				for (const result of visibilityResults) {
-					expect(result).toBe(firstResult);
-					expect(result).toBe(true); // Should always be true for enabled users
+					// All checks should return the same result
+					const firstResult = visibilityResults[0];
+					for (const result of visibilityResults) {
+						expect(result).toBe(firstResult);
+						expect(result).toBe(capabilities.includes(ENABLE_DISABLE_CAPABILITY));
+					}
 				}
-			}),
+			),
 			{ numRuns: 50 }
 		);
 	});
@@ -521,16 +609,23 @@ describe('Property 24: Disable Button Visibility', () => {
 	 */
 	it('should have mutually exclusive enable/disable button visibility', () => {
 		fc.assert(
-			fc.property(userDetailResponseArb, (user) => {
-				const shouldShowEnableButton = !user.enabled;
-				const shouldShowDisableButton = user.enabled;
+			fc.property(userDetailResponseArb, providerCapabilityArb, (user, capabilities) => {
+				setProviderCapabilities(user, capabilities);
 
-				// Exactly one should be true
-				expect(shouldShowEnableButton !== shouldShowDisableButton).toBe(true);
+				const providerSupportsEnableDisable = hasProviderCapability(
+					user.media_server.server_type,
+					ENABLE_DISABLE_CAPABILITY
+				);
+				const shouldShowEnableButton = providerSupportsEnableDisable && !user.enabled;
+				const shouldShowDisableButton = providerSupportsEnableDisable && user.enabled;
 
-				// XOR check
-				expect(shouldShowEnableButton || shouldShowDisableButton).toBe(true);
+				expect(providerSupportsEnableDisable).toBe(
+					capabilities.includes(ENABLE_DISABLE_CAPABILITY)
+				);
 				expect(shouldShowEnableButton && shouldShowDisableButton).toBe(false);
+				expect(shouldShowEnableButton || shouldShowDisableButton).toBe(
+					providerSupportsEnableDisable
+				);
 			}),
 			{ numRuns: 100 }
 		);

--- a/frontend/src/lib/components/users/user-detail.svelte.test.ts
+++ b/frontend/src/lib/components/users/user-detail.svelte.test.ts
@@ -437,6 +437,7 @@ describe('Property 22: Linked Users Display', () => {
 describe('Property 23: Enable Button Visibility', () => {
 	afterEach(() => {
 		cleanup();
+		setProviders([]);
 	});
 
 	/**
@@ -542,6 +543,7 @@ describe('Property 23: Enable Button Visibility', () => {
 describe('Property 24: Disable Button Visibility', () => {
 	afterEach(() => {
 		cleanup();
+		setProviders([]);
 	});
 
 	/**

--- a/frontend/src/lib/components/users/user-list.svelte.test.ts
+++ b/frontend/src/lib/components/users/user-list.svelte.test.ts
@@ -164,6 +164,7 @@ const userWithoutInvitationArb = userDetailResponseArb.map((user) => ({
 describe('Property 17: User Field Display', () => {
 	afterEach(() => {
 		cleanup();
+		setProviders([]);
 	});
 
 	/**

--- a/frontend/src/lib/components/users/user-list.svelte.test.ts
+++ b/frontend/src/lib/components/users/user-list.svelte.test.ts
@@ -258,6 +258,35 @@ describe('Property 17: User Field Display', () => {
 		);
 	});
 
+	it('should show enable or disable row action for Jellyfin users without provider metadata', () => {
+		fc.assert(
+			fc.property(userDetailResponseArb, (user) => {
+				const jellyfinUser = {
+					...user,
+					media_server: {
+						...user.media_server,
+						server_type: 'jellyfin' as const
+					}
+				};
+				setProviders([]);
+
+				const { container } = render(UserRow, { props: { user: jellyfinUser } });
+
+				if (jellyfinUser.enabled) {
+					expect(container.querySelector('[aria-label="Disable user"]')).not.toBeNull();
+					expect(container.querySelector('[aria-label="Enable user"]')).toBeNull();
+				} else {
+					expect(container.querySelector('[aria-label="Enable user"]')).not.toBeNull();
+					expect(container.querySelector('[aria-label="Disable user"]')).toBeNull();
+				}
+				expect(container.querySelector('[aria-label="Delete user"]')).not.toBeNull();
+
+				cleanup();
+			}),
+			{ numRuns: 50 }
+		);
+	});
+
 	/**
 	 * For any user, the server type badge SHALL be displayed with the provider label.
 	 */

--- a/frontend/src/lib/components/users/user-list.svelte.test.ts
+++ b/frontend/src/lib/components/users/user-list.svelte.test.ts
@@ -20,6 +20,7 @@ import type {
 	MediaServerResponse,
 	UserDetailResponse
 } from '$lib/api/client';
+import { setProviders } from '$lib/stores/providers.svelte';
 import UserFilters from './user-filters.svelte';
 import UserRow from './user-row.svelte';
 import UserTable from './user-table.svelte';
@@ -220,6 +221,39 @@ describe('Property 17: User Field Display', () => {
 				}
 			),
 			{ numRuns: 25 }
+		);
+	});
+
+	it('should hide enable and disable row actions for Plex users', () => {
+		fc.assert(
+			fc.property(userDetailResponseArb, (user) => {
+				const plexUser = {
+					...user,
+					media_server: {
+						...user.media_server,
+						server_type: 'plex' as const
+					}
+				};
+				setProviders([
+					{
+						server_type: 'plex',
+						display_name: 'Plex',
+						color: '#e5a00d',
+						icon_svg: '',
+						capabilities: ['create_user', 'delete_user', 'library_access'],
+						supported_permissions: []
+					}
+				]);
+
+				const { container } = render(UserRow, { props: { user: plexUser } });
+
+				expect(container.querySelector('[aria-label="Enable user"]')).toBeNull();
+				expect(container.querySelector('[aria-label="Disable user"]')).toBeNull();
+				expect(container.querySelector('[aria-label="Delete user"]')).not.toBeNull();
+
+				cleanup();
+			}),
+			{ numRuns: 50 }
 		);
 	});
 

--- a/frontend/src/lib/components/users/user-row.svelte
+++ b/frontend/src/lib/components/users/user-row.svelte
@@ -22,7 +22,7 @@ import StatusBadge, {
 } from "$lib/components/status-badge.svelte";
 import { Button } from "$lib/components/ui/button";
 import * as Table from "$lib/components/ui/table";
-import { getProviderBadgeStyle } from "$lib/stores/providers.svelte";
+import { getProviderBadgeStyle, hasProviderCapability } from "$lib/stores/providers.svelte";
 
 interface Props {
 	user: UserDetailResponse;
@@ -102,6 +102,9 @@ const expiresDisplay = $derived.by(() => {
 
 const badgeStyle = $derived(getProviderBadgeStyle(user.media_server.server_type));
 const userEmail = $derived(user.email ?? user.identity.email);
+const supportsEnableDisable = $derived(
+	hasProviderCapability(user.media_server.server_type, "enable_disable_user"),
+);
 
 /**
  * Navigate to user detail page.
@@ -235,7 +238,7 @@ function handleDelete() {
 			>
 				<Eye class="size-4" />
 			</Button>
-			{#if user.enabled}
+			{#if supportsEnableDisable && user.enabled}
 				<Button
 					variant="ghost"
 					size="icon-sm"
@@ -245,7 +248,7 @@ function handleDelete() {
 				>
 					<PowerOff class="size-4" />
 				</Button>
-			{:else}
+			{:else if supportsEnableDisable}
 				<Button
 					variant="ghost"
 					size="icon-sm"

--- a/frontend/src/lib/stores/providers.svelte.test.ts
+++ b/frontend/src/lib/stores/providers.svelte.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for provider metadata capability lookups.
+ *
+ * @module $lib/stores/providers.svelte.test
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { hasProviderCapability, setProviders } from './providers.svelte';
+
+const ENABLE_DISABLE_CAPABILITY = 'enable_disable_user';
+
+describe('Provider capability metadata', () => {
+	afterEach(() => {
+		setProviders([]);
+	});
+
+	it('uses built-in capabilities when provider metadata is absent', () => {
+		setProviders([]);
+
+		expect(hasProviderCapability('jellyfin', ENABLE_DISABLE_CAPABILITY)).toBe(true);
+		expect(hasProviderCapability('plex', ENABLE_DISABLE_CAPABILITY)).toBe(false);
+		expect(hasProviderCapability('unknown', ENABLE_DISABLE_CAPABILITY)).toBe(false);
+	});
+
+	it('uses loaded provider metadata over built-in capabilities', () => {
+		setProviders([
+			{
+				server_type: 'jellyfin',
+				display_name: 'Jellyfin',
+				color: '#00a4dc',
+				icon_svg: '',
+				capabilities: ['create_user'],
+				supported_permissions: []
+			}
+		]);
+
+		expect(hasProviderCapability('jellyfin', ENABLE_DISABLE_CAPABILITY)).toBe(false);
+	});
+});

--- a/frontend/src/lib/stores/providers.svelte.ts
+++ b/frontend/src/lib/stores/providers.svelte.ts
@@ -102,6 +102,13 @@ export function getAllProviders(): ProviderMeta[] {
 	return Array.from(providers.values());
 }
 
+/**
+ * Check whether a provider declares support for a capability.
+ */
+export function hasProviderCapability(serverType: string, capability: string): boolean {
+	return providers.get(serverType)?.capabilities.includes(capability) ?? false;
+}
+
 // =============================================================================
 // Style helpers
 // =============================================================================

--- a/frontend/src/lib/stores/providers.svelte.ts
+++ b/frontend/src/lib/stores/providers.svelte.ts
@@ -26,6 +26,14 @@ export interface ProviderMeta {
 // State
 // =============================================================================
 
+const BUILT_IN_PROVIDER_CAPABILITIES: ReadonlyMap<string, readonly string[]> = new Map([
+	[
+		'jellyfin',
+		['create_user', 'delete_user', 'enable_disable_user', 'library_access', 'download_permission']
+	],
+	['plex', ['create_user', 'delete_user', 'library_access', 'remove_shared_access']]
+]);
+
 // SAFETY: Module-level $state is shared during SSR (per guideline warning).
 // This is safe because: (1) only mutated client-side from $effect() in +layout.svelte,
 // (2) provider metadata is identical for all users (not per-user state).
@@ -106,7 +114,11 @@ export function getAllProviders(): ProviderMeta[] {
  * Check whether a provider declares support for a capability.
  */
 export function hasProviderCapability(serverType: string, capability: string): boolean {
-	return providers.get(serverType)?.capabilities.includes(capability) ?? false;
+	return (
+		providers.get(serverType)?.capabilities ??
+		BUILT_IN_PROVIDER_CAPABILITIES.get(serverType) ??
+		[]
+	).includes(capability);
 }
 
 // =============================================================================

--- a/frontend/src/routes/(admin)/users/[id]/+page.svelte
+++ b/frontend/src/routes/(admin)/users/[id]/+page.svelte
@@ -43,7 +43,7 @@ import { Button } from "$lib/components/ui/button";
 import * as Card from "$lib/components/ui/card";
 import { Label } from "$lib/components/ui/label";
 import UserPermissionsEditor from "$lib/components/users/user-permissions-editor.svelte";
-import { getProviderBadgeStyle } from "$lib/stores/providers.svelte";
+import { getProviderBadgeStyle, hasProviderCapability } from "$lib/stores/providers.svelte";
 import { showError, showSuccess } from "$lib/utils/toast";
 import type { PageData } from "./$types";
 
@@ -99,6 +99,11 @@ const statusLabel = $derived.by(() => {
 });
 
 const badgeStyle = $derived(data.user ? getProviderBadgeStyle(data.user.media_server.server_type) : '');
+const supportsEnableDisable = $derived(
+	data.user
+		? hasProviderCapability(data.user.media_server.server_type, "enable_disable_user")
+		: false,
+);
 
 /**
  * Format date for display.
@@ -591,7 +596,7 @@ function viewLinkedUser(userId: string) {
 				<Card.Content>
 					<div class="flex flex-wrap items-center gap-3">
 						<!-- Enable Button (visible when disabled) -->
-						{#if !data.user.enabled}
+						{#if supportsEnableDisable && !data.user.enabled}
 							<Button
 								onclick={handleEnable}
 								disabled={enabling || disabling || deleting}
@@ -608,7 +613,7 @@ function viewLinkedUser(userId: string) {
 						{/if}
 
 						<!-- Disable Button (visible when enabled) -->
-						{#if data.user.enabled}
+						{#if supportsEnableDisable && data.user.enabled}
 							<Button
 								onclick={handleDisable}
 								disabled={enabling || disabling || deleting}


### PR DESCRIPTION
## Summary

This PR fixes the Plex enable/disable unsupported flow by making user enable/disable operations capability-aware across the backend and frontend.

Plex does not support native account enable/disable. The backend now rejects direct enable/disable API calls for providers that do not advertise `enable_disable_user`, and the UI hides those actions for unsupported providers while preserving delete and shared-access cleanup actions.

## Changes

- Added a provider capability check in `UserService.set_enabled` before creating a media client.
- Return a clear validation error for unsupported providers, including Plex: `Enable/disable is not supported for Plex servers`.
- Preserve Jellyfin behavior by only updating the local user record after the external media server update succeeds.
- Added `hasProviderCapability` to the provider metadata store.
- Hid enable/disable actions in the user detail page when `enable_disable_user` is not supported.
- Hid enable/disable row actions in the user list for unsupported providers.
- Kept destructive delete actions available for Plex users.
- Added backend property coverage for unsupported providers, ensuring no client is created and local state is unchanged.
- Updated frontend property/render tests for capability-aware action visibility, including Plex cases.

## Verification

- `uv run pytest tests/property/test_user_service_props.py -k EnableDisableAtomicity -n0`
- `uv run ruff check src/zondarr/services/user.py tests/property/test_user_service_props.py`
- `uv run basedpyright src/zondarr/services/user.py tests/property/test_user_service_props.py`
- `bun run --cwd frontend test -- src/lib/components/users/user-detail.svelte.test.ts src/lib/components/users/user-list.svelte.test.ts`
- `frontend/node_modules/.bin/biome check 'frontend/src/routes/(admin)/users/[id]/+page.svelte' frontend/src/lib/stores/providers.svelte.ts frontend/src/lib/components/users/user-detail.svelte.test.ts frontend/src/lib/components/users/user-row.svelte frontend/src/lib/components/users/user-list.svelte.test.ts`
- `bun run --cwd frontend check`
