### PR TITLE
fix(frontend): add default browser tab title

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -30,6 +30,7 @@ $effect(() => {
 </script>
 
 <svelte:head>
+	<title>Zondarr</title>
 	<link rel="icon" type="image/svg+xml" href={favicon} />
 </svelte:head>
 


### PR DESCRIPTION
## Summary

The browser tab for Zondarr was showing the raw URL (for example `zondarr.cccp.ps/dashbo…`) instead of an app name. This was because no `<title>` element was ever set: `frontend/src/app.html` does not declare one, and the root layout's `<svelte:head>` only injected the favicon.

This PR adds a default `<title>Zondarr</title>` to the root `+layout.svelte`'s `<svelte:head>` so every route renders a sensible tab title. Individual pages can still override it later via their own `<svelte:head><title>…</title></svelte:head>` if per-page titles such as `Zondarr · Dashboard` are desired.

## Changes

- `frontend/src/routes/+layout.svelte`: add `<title>Zondarr</title>` inside the existing `<svelte:head>` block, alongside the favicon link.

## Test plan

- [ ] Run `uv run dev_cli` and confirm the browser tab shows `Zondarr` on `/`, `/login`, `/dashboard`, and other admin routes.
- [ ] Visit `/join/<code>` and confirm the tab title is still `Zondarr` (its existing `<svelte:head>` only sets a referrer meta tag and does not override the title).
- [ ] Verify the favicon still loads in the tab.